### PR TITLE
[Add Task] Fix category save path not updating

### DIFF
--- a/qBitControl/TorrentView/TorrentAddView.swift
+++ b/qBitControl/TorrentView/TorrentAddView.swift
@@ -107,8 +107,12 @@ struct TorrentAddView: View {
             Section(header: Text("Info")) {
                 Picker("Category", selection: $viewModel.category) {
                     ForEach(viewModel.categoriesArr, id: \.self) { category in Text(category).tag(category) }
+                }.onChange(of: viewModel.category) { category in
+                    if let newSavePath = viewModel.categoriesPaths[category] {
+                        viewModel.savePath = newSavePath
+                    }
                 }
-                
+
                 Picker("Tags", selection: $viewModel.tags) {
                     ForEach(viewModel.tagsArr, id: \.self) { tag in Text(tag).tag(tag) }
                 }


### PR DESCRIPTION
Fix for Issue https://github.com/Michael-128/qBitControl/issues/14

Previously, changing the category did nothing to update the save path. This change adds an `onChange` event to update the view model with the new category.

Tests:
Added a task, changed the category, verified in Qbit that the save path is correct.