### PR TITLE
[Categories] Use Category struct instead of [String: [String: String]]

### DIFF
--- a/qBitControl/Classes/qBitRequestClass.swift
+++ b/qBitControl/Classes/qBitRequestClass.swift
@@ -152,12 +152,12 @@ class qBitRequest {
         }.resume()
     }
     
-    static func requestCategoriesJSON(request: URLRequest, completionHandler: @escaping ([String: [String: String]]) -> Void) {
+    static func requestCategoriesJSON(request: URLRequest, completionHandler: @escaping ([String: Category]) -> Void) {
         URLSession.shared.dataTask(with: request) {
                 data, response, error in
                 if let data = data {
                     do {
-                        let json = try JSONDecoder().decode([String: [String: String]].self, from: data)
+                        let json = try JSONDecoder().decode([String: Category].self, from: data)
                         completionHandler(json)
                     } catch {
                         print(error)

--- a/qBitControl/Classes/qBittorrentClass.swift
+++ b/qBitControl/Classes/qBittorrentClass.swift
@@ -225,7 +225,7 @@ class qBittorrent {
         qBitRequest.requestPreferencesJSON(request: request, completionHandler: completionHandler)
     }
     
-    static func getCategories(completionHandler: @escaping ([String: [String: String]]) -> Void) {
+    static func getCategories(completionHandler: @escaping ([String: Category]) -> Void) {
         let request = qBitRequest.prepareURLRequest(path: "/api/v2/torrents/categories")
         
         qBitRequest.requestCategoriesJSON(request: request, completionHandler: completionHandler)
@@ -579,8 +579,7 @@ class qBittorrent {
      @State private var ratioLimit = ""
      @State private var seedingTimeLimit = ""
      
-     @State private var categoriesArr = ["None"]
-     @State private var categoriesPaths = ["None": ""]
+     @State private var categories = []
      @State private var tagsArr: [String] = ["None"]
      */
     

--- a/qBitControl/Structures.swift
+++ b/qBitControl/Structures.swift
@@ -416,3 +416,8 @@ struct AlertIdentifier: Identifiable {
 
     var id: Choice
 }
+
+struct Category: Decodable, Hashable {
+    let name: String
+    let savePath: String
+}

--- a/qBitControl/TorrentView/TorrentAddView.swift
+++ b/qBitControl/TorrentView/TorrentAddView.swift
@@ -99,18 +99,18 @@ struct TorrentAddView: View {
         }
         .fileImporter(isPresented: $viewModel.isFileImporter, allowedContentTypes: [.data], allowsMultipleSelection: true, onCompletion: viewModel.handleTorrentFiles)
     }
-    
+
     func torrentOptionsView() -> some View {
         Group {
             Section(header: Text("Save Path")) { TextField("Path", text: $viewModel.savePath) }
             
             Section(header: Text("Info")) {
                 Picker("Category", selection: $viewModel.category) {
-                    ForEach(viewModel.categoriesArr, id: \.self) { category in Text(category).tag(category) }
-                }.onChange(of: viewModel.category) { category in
-                    if let newSavePath = viewModel.categoriesPaths[category] {
-                        viewModel.savePath = newSavePath
+                    ForEach(viewModel.categories, id: \.self) { category in
+                        Text(category.name).tag(category.name)
                     }
+                }.onChange(of: viewModel.category) { category in
+                    viewModel.savePath = category.savePath
                 }
 
                 Picker("Tags", selection: $viewModel.tags) {

--- a/qBitControl/TorrentView/TorrentAddView.swift
+++ b/qBitControl/TorrentView/TorrentAddView.swift
@@ -107,8 +107,12 @@ struct TorrentAddView: View {
             Section(header: Text("Info")) {
                 Picker("Category", selection: $viewModel.category) {
                     ForEach(viewModel.categoriesArr, id: \.self) { category in Text(category).tag(category) }
+                }.onChange(of: viewModel.category) { category in
+                    if let newSavePath = viewModel.categoriesPaths[category] {
+                        viewModel.savePath = newSavePath
+                    }
                 }
-                
+
                 Picker("Tags", selection: $viewModel.tags) {
                     ForEach(viewModel.tagsArr, id: \.self) { tag in Text(tag).tag(tag) }
                 }

--- a/qBitControl/TorrentView/TorrentDetailsView.swift
+++ b/qBitControl/TorrentView/TorrentDetailsView.swift
@@ -9,8 +9,8 @@ struct ChangeCategoryView: View {
     
     @State var torrentHash: String
     
-    @State private var categories: [String] = []
-    
+    @State private var categories: [Category] = []
+
     @State var category: String
 
     
@@ -20,9 +20,8 @@ struct ChangeCategoryView: View {
                 if categories.count > 1 {
                     Picker("Categories", selection: $category) {
                         Text("None").tag("")
-                        ForEach(categories, id: \.self) {
-                            category in
-                            Text(category).tag(category)
+                        ForEach(categories, id: \.self) { category in
+                            Text(category.name).tag(category.name)
                         }
                     }.pickerStyle(.inline)
                 }
@@ -37,13 +36,9 @@ struct ChangeCategoryView: View {
             }
             .navigationTitle("Categories")
         }.onAppear() {
-            qBittorrent.getCategories(completionHandler: {
-                categories in
-                
-                for (category, _) in categories {
-                    self.categories.append(category)
-                    self.categories.sort(by: <)
-                }
+            qBittorrent.getCategories(completionHandler: { response in
+                // Append sorted list of Category objects to ensure "None" always appears at the top
+                self.categories.append(contentsOf: response.map { $1 }.sorted { $0.name < $1.name })
             })
         }.onChange(of: category) {
             category in

--- a/qBitControl/TorrentView/TorrentFilterView.swift
+++ b/qBitControl/TorrentView/TorrentFilterView.swift
@@ -12,7 +12,7 @@ struct TorrentFilterView: View {
     @Binding var reverse: Bool
     @Binding var filter: String
     
-    @State private var categoriesArr: [String] = []
+    @State private var categories: [Category] = []
     @State private var tagsArr: [String] = []
     
     @Binding var category: String
@@ -33,13 +33,12 @@ struct TorrentFilterView: View {
                     }
                 }
                 
-                if categoriesArr.count > 1 {
+                if categories.count > 1 {
                     Picker("Categories", selection: $category) {
                         Text("None").tag("None")
                         Text("Uncategorized").tag("")
-                        ForEach(categoriesArr, id: \.self) {
-                            category1 in
-                            Text(category1).tag(category1)
+                        ForEach(categories, id: \.self) { theCategory in
+                            Text(theCategory.name).tag(theCategory.name)
                         }
                     }.pickerStyle(.inline)
                 }
@@ -154,11 +153,9 @@ struct TorrentFilterView: View {
                     }
                 }
             }.onAppear() {
-                qBittorrent.getCategories(completionHandler: {
-                    categories in
-                    for (key, _) in categories {
-                        categoriesArr.append(key)
-                    }
+                qBittorrent.getCategories(completionHandler: { response in
+                    // Append sorted list of Category objects to ensure "None" always appears at the top
+                    self.categories.append(contentsOf: response.map { $1 }.sorted { $0.name < $1.name })
                 })
                 qBittorrent.getTags(completionHandler: {
                     tags in


### PR DESCRIPTION
This fixes #16 and also generally improves how Categories function across the app. I've eliminated the separate arrays for category names and save paths, and simplified the completion handlers to always sort remote categories before appending them to the array. 

There are more optimizations that should be done here (possibly a CategoryManager to avoid refetching categories so frequently?) but for now this change should prevent any weirdness from the qBittorrent JSON response.

Tests:
Added a new torrent and verified that categories download regardless of `download_path` being set to No. Categories display sorted in filter view and in torrent details view. Changing the category updates the category in qBittorrent in real time.

Note: this PR depends on #15 so ignore the older commit in this PR, as ideally that one should be merged first.