### PR TITLE
Add AltStore source badges in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,14 @@ Get qBitControl by adding Michael-128 source from the list of recommended source
 - AltStore PAL: `https://raw.githubusercontent.com/Michael-128/qBitControl-releases/main/source.json`
 - AltStore: `https://raw.githubusercontent.com/Michael-128/qBitControl-releases/main/source-classic.json`
 
+<a href="https://intradeus.github.io/http-protocol-redirector?r=altstore://source?url=https://raw.githubusercontent.com/Michael-128/qBitControl-releases/main/source.json"><img src="https://github.com/user-attachments/assets/0cadc474-ca12-4b83-b04c-2962087cabcb" alt="Add to AltStore PAL" height="60"></a>
+
+<a href="https://intradeus.github.io/http-protocol-redirector?r=altstore://source?url=https://raw.githubusercontent.com/Michael-128/qBitControl-releases/main/source-classic.json"><img src="https://github.com/user-attachments/assets/5db51b73-1ea5-4756-960e-4e603943dcc4" alt="Add to AltStore Classic" height="60"></a>
+&nbsp;
+<a href="https://intradeus.github.io/http-protocol-redirector?r=sidestore://source?url=https://raw.githubusercontent.com/Michael-128/qBitControl-releases/main/source-classic.json"><img src="https://github.com/user-attachments/assets/6e819693-91eb-40d1-b246-7934505623db" alt="Add to SideStore" height="60"></a>
+&nbsp;
+<a href="https://intradeus.github.io/http-protocol-redirector?r=feather://source/https://raw.githubusercontent.com/Michael-128/qBitControl-releases/main/source-classic.json"><img src="https://github.com/user-attachments/assets/5436ea36-c93b-4477-a663-6cadcfa736a3" alt="Add to Feather" height="60"></a>
+
 ## Features ✨
 - Add torrents via .torrent files or magnet links.
 - Monitor download progress.


### PR DESCRIPTION
Taking inspiration from repos such as https://github.com/Balackburn/Apollo and https://github.com/lo-cafe/winston, I’ve added badges that make it easy to quickly add the AltStore source on an iOS device.

https://github.com/user-attachments/assets/97f2eb83-e85a-42a4-ab33-4a03e47518a7

![CleanShot 2025-05-21 at 20 20 41](https://github.com/user-attachments/assets/f09c4828-9a88-4131-9d80-1c07486b0e62)

Regarding the ⁠`https://intradeus.github.io/http-protocol-redirector?r` URL: this is necessary because GitHub restricts the use of non-http(s) schemas for [security reasons](https://github.com/orgs/community/discussions/27857). Using https://github.com/intradeus/http-protocol-redirector should be safe, but I’ll let you decide.

Also, here are a few other options. Let me know if you’d like me to add/change, or if the setup shown in the screenshot above works for you:
1. If the ⁠`Add to AltStore Classic` badge feels too wide, I also have a narrower `⁠Add to AltStore` badge available.
2. The badges are currently set to a height of 60. I can reduce this to 40 or 50 if you prefer them shorter.
3. I can add a `⁠Download from GitHub` badge that links directly to https://github.com/Michael-128/qBitControl/releases/latest.
4. I have the badges in `svg` but I opted for `png` since they're quite smaller in file sizes.
5. I chose the classic Dark style badge, but an alternative Light variant is also possible. Maybe making only the GitHub badge in Light would make sense to separate it more clearly? 

![CleanShot 2025-05-21 at 20 25 22](https://github.com/user-attachments/assets/95a4c1a0-a360-40cf-962c-cd8e758add12)

![CleanShot 2025-05-21 at 22 36 20](https://github.com/user-attachments/assets/093132b4-6db6-4075-8f15-572d0c88454f)