### PR TITLE
[Fix] sanitize the server url for trailing slashes while adding a server

### DIFF
--- a/qBitControl/ViewModels/ServersView/ServerAddViewModel.swift
+++ b/qBitControl/ViewModels/ServersView/ServerAddViewModel.swift
@@ -84,6 +84,7 @@ class ServerAddViewModel: ObservableObject {
     func addServer(dismiss: DismissAction) -> Void {
         if(!validateInputs()) { return; }
         if(!validateIsConnecting()) { return; }
+        sanitizeInputs()
         
         let server = Server(name: friendlyName, url: url, username: username, password: password, basicAuth: basicAuth)
         
@@ -108,5 +109,9 @@ class ServerAddViewModel: ObservableObject {
                 self.isCheckingConnection = false
             }
         })
+    }
+    
+    private func sanitizeInputs() {
+        url = url.replacingOccurrences(of: "/+$", with: "", options: .regularExpression)
     }
 }


### PR DESCRIPTION
### Summary
Normalize user-entered server URLs by removing any trailing slash characters before saving or testing the connection. This ensures consistent URL formatting across the app and avoids duplicate entries or subtle connection issues caused by extra slashes.

### What changed
- Added `sanitizeInputs()` to `ServerAddViewModel` that strips trailing slashes using a regex:
  - `url = url.replacingOccurrences(of: "/+$", with: "", options: .regularExpression)`
- Invoked `sanitizeInputs()` at the start of `addServer(dismiss:)`, after input validation and before:
  - building the `Server` model
  - attempting a connection check
  - persisting the server

### Why this is needed
- Users may paste URLs ending with `/` or multiple `///`.
- Trailing slashes can lead to:
  - Mismatched URLs when comparing or deduplicating servers
  - Inconsistent request paths when constructing endpoints
  - Confusing UI where the same server appears as different entries

Normalizing the URL at the point of creation/editing prevents these issues and keeps storage/logic consistent.

### How it works
- The regex `"/+$"` matches one or more slashes at the end of the string and removes them.
- Examples:
  - `https://example.com/` → `https://example.com`
  - `http://example.com///` → `http://example.com`
- Note: This field represents the base server URL; normalizing to the host/root avoids accidental path suffixes.

### Risk assessment
- Low risk. Only trailing slashes are removed; scheme, host, ports, and credentials remain unchanged.
- No behavioral change when the URL is already normalized.

### Testing
- Manually verified adding servers with:
  - `https://example.com/` → saved as `https://example.com`
  - `http://example.com///` → saved as `http://example.com`
- Confirmed connectivity check runs against the sanitized URL.
- Edited an existing server with trailing slashes and confirmed it is normalized upon save.