### PR TITLE
[Translate] Refine and complete Chinese translations

### DIFF
--- a/Localization/Localizations/Localizable.xcstrings
+++ b/Localization/Localizations/Localizable.xcstrings
@@ -2795,13 +2795,13 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "已完成"
+            "value" : "完成"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "已完成"
+            "value" : "完成"
           }
         }
       }

--- a/Localization/Localizations/Localizable.xcstrings
+++ b/Localization/Localizations/Localizable.xcstrings
@@ -1157,14 +1157,14 @@
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "All categories"
+            "state" : "translated",
+            "value" : "全部分类"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "All categories"
+            "state" : "translated",
+            "value" : "全部分類"
           }
         }
       }
@@ -1342,6 +1342,18 @@
             "state" : "translated",
             "value" : "Czy na pewno chcesz wznosić obecnie wyświetlane zadania?"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "确定要恢复当前任务吗？"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "確定要恢復當前任務嗎？"
+          }
         }
       }
     },
@@ -1386,7 +1398,20 @@
       }
     },
     "Basic Authentication" : {
-
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "基本认证"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "基本驗證"
+          }
+        }
+      }
     },
     "Books" : {
       "extractionState" : "manual",
@@ -1417,14 +1442,14 @@
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Books"
+            "state" : "translated",
+            "value" : "图书"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Books"
+            "state" : "translated",
+            "value" : "圖書"
           }
         }
       }
@@ -1961,6 +1986,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Potwierdź Wznowienie Zadań"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "确认恢复当前任务"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "確認恢復當前任務"
           }
         }
       }
@@ -2561,47 +2598,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "遞減"
-          }
-        }
-      }
-    },
-    "Deselect All" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "すべて選択解除"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Odznacz Wszystkie"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Deselect All"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Deselect All"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "取消全部"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "取消選取"
           }
         }
       }
@@ -3635,14 +3631,14 @@
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Games"
+            "state" : "translated",
+            "value" : "游戏"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Games"
+            "state" : "translated",
+            "value" : "遊戲"
           }
         }
       }
@@ -4036,14 +4032,14 @@
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Leechers"
+            "state" : "translated",
+            "value" : "下载者"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Leechers"
+            "state" : "translated",
+            "value" : "下載者"
           }
         }
       }
@@ -4477,14 +4473,14 @@
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Movies"
+            "state" : "translated",
+            "value" : "电影"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Movies"
+            "state" : "translated",
+            "value" : "電影"
           }
         }
       }
@@ -4518,14 +4514,14 @@
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Music"
+            "state" : "translated",
+            "value" : "音乐"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Music"
+            "state" : "translated",
+            "value" : "音樂"
           }
         }
       }
@@ -4678,14 +4674,14 @@
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "No results"
+            "state" : "translated",
+            "value" : "无结果"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "No results"
+            "state" : "translated",
+            "value" : "無結果"
           }
         }
       }
@@ -6086,14 +6082,14 @@
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "results"
+            "state" : "translated",
+            "value" : "个结果"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "results"
+            "state" : "translated",
+            "value" : "個結果"
           }
         }
       }
@@ -6190,6 +6186,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Wznów Wyświetlone Zadania"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "恢复当前任务"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "恢復當前任務"
           }
         }
       }
@@ -6314,47 +6322,6 @@
         }
       }
     },
-    "Running..." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "実行中..."
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "W trakcie..."
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Running..."
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Running..."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Running..."
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Running..."
-          }
-        }
-      }
-    },
     "Save" : {
       "localizations" : {
         "ja" : {
@@ -6379,47 +6346,6 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Save"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "保存"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "儲存"
-          }
-        }
-      }
-    },
-    "SAVE" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "保存"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ZAPISZ"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "SAVE"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "SAVE"
           }
         },
         "zh-Hans" : {
@@ -6504,14 +6430,14 @@
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Search"
+            "state" : "translated",
+            "value" : "搜索"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Search"
+            "state" : "translated",
+            "value" : "搜尋"
           }
         }
       }
@@ -6545,14 +6471,14 @@
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Seeders"
+            "state" : "translated",
+            "value" : "做种者"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Seeders"
+            "state" : "translated",
+            "value" : "做種者"
           }
         }
       }
@@ -6753,47 +6679,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "選取"
-          }
-        }
-      }
-    },
-    "Select All" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "すべて選択"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wybierz Wszystko"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Select All"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Select All"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "选择全部"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "選取所有"
           }
         }
       }
@@ -7227,14 +7112,14 @@
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Software"
+            "state" : "translated",
+            "value" : "软件"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Software"
+            "state" : "translated",
+            "value" : "軟體"
           }
         }
       }
@@ -7347,14 +7232,14 @@
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Start"
+            "state" : "translated",
+            "value" : "开始"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Start"
+            "state" : "translated",
+            "value" : "開始"
           }
         }
       }
@@ -7520,7 +7405,20 @@
       }
     },
     "Stop" : {
-
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "停止"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "停止"
+          }
+        }
+      }
     },
     "Stop Force Start" : {
       "localizations" : {
@@ -7952,14 +7850,14 @@
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "TV shows"
+            "state" : "translated",
+            "value" : "电视剧"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "TV shows"
+            "state" : "translated",
+            "value" : "電視劇"
           }
         }
       }


### PR DESCRIPTION
I tried to contribute translations through Crowdin, but I was shown a “Project not found” error. Therefore, I created this PR instead.

This pull request updates the Simplified Chinese (`zh-Hans`) and Traditional Chinese (`zh-Hant`) localizations in the `Localizable.xcstrings` file. It provides new translations for many UI strings, replacing previous placeholder English text or untranslated entries. Additionally, several unused or stale keys (such as "Deselect All", "Select All", "SAVE", and "Running...") have been removed.

**Localization updates:**

* Added or updated Chinese translations for UI strings such as "All categories", "Books", "Games", "Movies", "Music", "No results", "results", "Search", "Seeders", "Software", "Start", "Stop", "TV shows", and more, ensuring the app is more accessible to Chinese-speaking users. [[1]](diffhunk://#diff-7c7517a3b01a996d2b7f1c19a4f08169d2a69cb75bdc2c9598f8b2aee4a8083cL1160-R1167) [[2]](diffhunk://#diff-7c7517a3b01a996d2b7f1c19a4f08169d2a69cb75bdc2c9598f8b2aee4a8083cL1420-R1452) [[3]](diffhunk://#diff-7c7517a3b01a996d2b7f1c19a4f08169d2a69cb75bdc2c9598f8b2aee4a8083cL3638-R3641) [[4]](diffhunk://#diff-7c7517a3b01a996d2b7f1c19a4f08169d2a69cb75bdc2c9598f8b2aee4a8083cL4480-R4483) [[5]](diffhunk://#diff-7c7517a3b01a996d2b7f1c19a4f08169d2a69cb75bdc2c9598f8b2aee4a8083cL4521-R4524) [[6]](diffhunk://#diff-7c7517a3b01a996d2b7f1c19a4f08169d2a69cb75bdc2c9598f8b2aee4a8083cL4681-R4684) [[7]](diffhunk://#diff-7c7517a3b01a996d2b7f1c19a4f08169d2a69cb75bdc2c9598f8b2aee4a8083cL6089-R6092) [[8]](diffhunk://#diff-7c7517a3b01a996d2b7f1c19a4f08169d2a69cb75bdc2c9598f8b2aee4a8083cL6507-R6440) [[9]](diffhunk://#diff-7c7517a3b01a996d2b7f1c19a4f08169d2a69cb75bdc2c9598f8b2aee4a8083cL6548-R6481) [[10]](diffhunk://#diff-7c7517a3b01a996d2b7f1c19a4f08169d2a69cb75bdc2c9598f8b2aee4a8083cL7230-R7122) [[11]](diffhunk://#diff-7c7517a3b01a996d2b7f1c19a4f08169d2a69cb75bdc2c9598f8b2aee4a8083cL7350-R7242) [[12]](diffhunk://#diff-7c7517a3b01a996d2b7f1c19a4f08169d2a69cb75bdc2c9598f8b2aee4a8083cL7523-R7421) [[13]](diffhunk://#diff-7c7517a3b01a996d2b7f1c19a4f08169d2a69cb75bdc2c9598f8b2aee4a8083cL7955-R7860)

* Added Chinese translations for authentication and task-related prompts, such as "Basic Authentication", "Are you sure you want to resume the currently displayed tasks?", and confirmation dialogs. [[1]](diffhunk://#diff-7c7517a3b01a996d2b7f1c19a4f08169d2a69cb75bdc2c9598f8b2aee4a8083cL1389-R1414) [[2]](diffhunk://#diff-7c7517a3b01a996d2b7f1c19a4f08169d2a69cb75bdc2c9598f8b2aee4a8083cR1345-R1356) [[3]](diffhunk://#diff-7c7517a3b01a996d2b7f1c19a4f08169d2a69cb75bdc2c9598f8b2aee4a8083cR1990-R2001) [[4]](diffhunk://#diff-7c7517a3b01a996d2b7f1c19a4f08169d2a69cb75bdc2c9598f8b2aee4a8083cR6190-R6201)

**Cleanup and removal of unused keys:**

* Removed unused or stale localization keys and their translations, including "Deselect All", "Select All", "SAVE", and "Running...". [[1]](diffhunk://#diff-7c7517a3b01a996d2b7f1c19a4f08169d2a69cb75bdc2c9598f8b2aee4a8083cL2568-L2608) [[2]](diffhunk://#diff-7c7517a3b01a996d2b7f1c19a4f08169d2a69cb75bdc2c9598f8b2aee4a8083cL6760-L6800) [[3]](diffhunk://#diff-7c7517a3b01a996d2b7f1c19a4f08169d2a69cb75bdc2c9598f8b2aee4a8083cL6398-L6438) [[4]](diffhunk://#diff-7c7517a3b01a996d2b7f1c19a4f08169d2a69cb75bdc2c9598f8b2aee4a8083cL6317-L6357)

**Minor translation improvements:**

* Improved the accuracy and naturalness of some existing Chinese translations, such as changing "已完成" to "完成" for "Completed".

Overall, these changes significantly enhance the quality and coverage of Chinese localizations and remove unused keys to keep the resource file clean and maintainable.