### PR TITLE
fix: peers JSON decoding

### DIFF
--- a/qBitControl/Components/PeersRowView.swift
+++ b/qBitControl/Components/PeersRowView.swift
@@ -34,7 +34,7 @@ struct PeerRowView: View {
         } label: {
             VStack {
                 HStack {
-                    Text("\(emojiFlag(regionCode:peer.country_code) ?? "")")
+                    Text("\(emojiFlag(regionCode:peer.country_code ?? "") ?? "")")
                     Text("\(peer.ip)")
                     Spacer()
                 }

--- a/qBitControl/Models/Peer.swift
+++ b/qBitControl/Models/Peer.swift
@@ -6,8 +6,8 @@ import Foundation
 struct Peer: Decodable {
     let client: String
     let connection: String
-    let country: String
-    let country_code: String
+    let country: String?
+    let country_code: String?
     let dl_speed: Int64
     let downloaded: Int64
     let files: String

--- a/qBitControl/Views/TorrentViews/PeerDetailsView.swift
+++ b/qBitControl/Views/TorrentViews/PeerDetailsView.swift
@@ -13,7 +13,7 @@ struct PeerDetailsView: View {
         List {
             Section(header: Text("Information")) {
                 CustomLabelView(label: "Client", value: peer.client)
-                CustomLabelView(label: "Country", value: peer.country)
+                CustomLabelView(label: "Country", value: peer.country ?? "-")
                 CustomLabelView(label: "IP", value: peer.ip)
                 CustomLabelView(label: "Port", value: "\(peer.port)")
                 CustomLabelView(label: "Connection", value: peer.connection)


### PR DESCRIPTION
the decoding error was:
> DecodingError.valueNotFound: Expected value of type String but found null instead. Path: peers.`149.22.91.88:13409`.country. Debug description: Cannot get value of type String -- found null value instead

sample response:
```json
{
    "full_update": true,
    "peers": {
        "149.22.91.88:13409": {
            "client": "qBittorrent 4.6.4",
            "connection": "μTP",
            "country": null,
            "country_code": null,
            "dl_speed": 0,
            "downloaded": 0,
            "files": "",
            "flags": "U K I H P",
            "flags_desc": "U = Interested (peer) and unchoked (local)\nK = Not interested (local) and unchoked (peer)\nI = Incoming connection\nH = Peer from DHT\nP = μTP",
            "host_name": "",
            "ip": "149.22.91.88",
            "peer_id_client": "-qB4640-",
            "port": 13409,
            "progress": 0.8203592896461487,
            "relevance": 0,
            "up_speed": 482932,
            "uploaded": 2617758767
        }
    },
    "rid": 1,
    "show_flags": false
}
```

fixes #72