### PR TITLE
feat(client): define TorrentClientProtocol and DI structure

### DIFF
--- a/qBitControl.xcodeproj/project.pbxproj
+++ b/qBitControl.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		90EF6A4D29093142001E9F02 /* TorrentClientProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90EF6A4D29093142001E9F01 /* TorrentClientProtocol.swift */; };
+		90EF6A4D29093142001E9F04 /* qBittorrentClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90EF6A4D29093142001E9F03 /* qBittorrentClient.swift */; };
+		90EF6A4D29093142001E9F06 /* MockTorrentClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90EF6A4D29093142001E9F05 /* MockTorrentClient.swift */; };
 		901230522DB02E8B0022FD4C /* SearchResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 901230512DB02E870022FD4C /* SearchResponse.swift */; };
 		901230542DB02EAE0022FD4C /* SearchResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 901230532DB02EAA0022FD4C /* SearchResult.swift */; };
 		901230562DB037120022FD4C /* SearchRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 901230552DB0370F0022FD4C /* SearchRowView.swift */; };
@@ -120,6 +123,9 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		90EF6A4D29093142001E9F01 /* TorrentClientProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TorrentClientProtocol.swift; sourceTree = "<group>"; };
+		90EF6A4D29093142001E9F03 /* qBittorrentClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = qBittorrentClient.swift; sourceTree = "<group>"; };
+		90EF6A4D29093142001E9F05 /* MockTorrentClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTorrentClient.swift; sourceTree = "<group>"; };
 		901230512DB02E870022FD4C /* SearchResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResponse.swift; sourceTree = "<group>"; };
 		901230532DB02EAA0022FD4C /* SearchResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResult.swift; sourceTree = "<group>"; };
 		901230552DB0370F0022FD4C /* SearchRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchRowView.swift; sourceTree = "<group>"; };
@@ -257,6 +263,9 @@
 		903DED2C290A8A2000FB36D6 /* Classes */ = {
 			isa = PBXGroup;
 			children = (
+				90EF6A4D29093142001E9F01 /* TorrentClientProtocol.swift */,
+				90EF6A4D29093142001E9F03 /* qBittorrentClient.swift */,
+				90EF6A4D29093142001E9F05 /* MockTorrentClient.swift */,
 				90DF6C6E2E89BF1E004562C1 /* SystemHelper.swift */,
 				90EF6A482909267A001E9E7F /* AuthClass.swift */,
 				9082FA4C29082208006C3960 /* qBittorrentClass.swift */,
@@ -673,6 +682,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				90EF6A4D29093142001E9F02 /* TorrentClientProtocol.swift in Sources */,
+				90EF6A4D29093142001E9F04 /* qBittorrentClient.swift in Sources */,
+				90EF6A4D29093142001E9F06 /* MockTorrentClient.swift in Sources */,
 				907C632D2DAEDC28004B1F41 /* SearchViewModel.swift in Sources */,
 				90E86FFE2C81C89A00F4EA01 /* qBitDataClass.swift in Sources */,
 				90EF6A4D29093142001E9E7F /* qBitRequestClass.swift in Sources */,

--- a/qBitControl/Classes/MockTorrentClient.swift
+++ b/qBitControl/Classes/MockTorrentClient.swift
@@ -1,0 +1,201 @@
+//
+//  MockTorrentClient.swift
+//  qBitControl
+//
+
+import Foundation
+
+class MockTorrentClient: TorrentClientProtocol {
+    
+    // Static mock helpers
+    static let mockVersion = Version(major: 5, minor: 0, patch: 0)
+    
+    static let mockGlobalTransferInfo = GlobalTransferInfo(
+        fetchDate: Date(),
+        dlspeed: 1024 * 1024 * 5, // 5 MB/s
+        dldata: 1024 * 1024 * 1024 * 10, // 10 GB
+        dllimit: 0,
+        upspeed: 1024 * 512, // 512 KB/s
+        updata: 1024 * 1024 * 1024 * 2, // 2 GB
+        uplimit: 0,
+        dhtnodes: 234,
+        connection_status: "connected"
+    )
+    
+    static let mockCategory = Category(name: "Movies", savePath: "/Downloads/Movies")
+    
+    static let mockTracker = Tracker(
+        url: "udp://tracker.coppersurfer.tk:6969/announce",
+        status: 2,
+        tier: 0,
+        num_peers: 42,
+        num_seeds: 18,
+        num_leeches: 24,
+        num_downloaded: 1500,
+        msg: "Working"
+    )
+    
+    static let mockSearchPlugin = SearchPlugin(
+        enabled: true,
+        fullName: "The Pirate Bay",
+        name: "piratebay",
+        supportedCategories: [SearchCategory(name: "All", id: "all")],
+        url: "https://thepiratebay.org",
+        version: "1.2.3"
+    )
+    
+    static func mockPreferences() -> qBitPreferences {
+        let json = "{}"
+        return try! JSONDecoder().decode(qBitPreferences.self, from: json.data(using: .utf8)!)
+    }
+    
+    init() {}
+    
+    // MARK: - TorrentTaskActions
+    
+    func pauseTorrent(hash: String) async throws {}
+    func pauseTorrents(hashes: [String]) async throws {}
+    func pauseAllTorrents() async throws {}
+    
+    func resumeTorrent(hash: String) async throws {}
+    func resumeTorrents(hashes: [String]) async throws {}
+    func resumeAllTorrents() async throws {}
+    
+    func recheckTorrent(hash: String) async throws {}
+    func recheckTorrents(hashes: [String]) async throws {}
+    
+    func reannounceTorrent(hash: String) async throws {}
+    func reannounceTorrents(hashes: [String]) async throws {}
+    
+    func deleteTorrent(hash: String, deleteFiles: Bool) async throws {}
+    func deleteTorrents(hashes: [String], deleteFiles: Bool) async throws {}
+    
+    func increasePriorityTorrents(hashes: [String]) async throws {}
+    func decreasePriorityTorrents(hashes: [String]) async throws {}
+    func topPriorityTorrents(hashes: [String]) async throws {}
+    func bottomPriorityTorrents(hashes: [String]) async throws {}
+    
+    func toggleSequentialDownload(hashes: [String]) async throws {}
+    func toggleFLPiecesFirst(hashes: [String]) async throws {}
+    func setForceStart(hashes: [String], value: Bool) async throws {}
+    
+    func addMagnetTorrent(
+        torrent: URLQueryItem,
+        savePath: String = "",
+        cookie: String = "",
+        category: String = "",
+        tags: String = "",
+        skipChecking: Bool = false,
+        paused: Bool = false,
+        sequentialDownload: Bool = false,
+        dlLimit: Int = -1,
+        upLimit: Int = -1,
+        ratioLimit: Float = -1.0,
+        seedingTimeLimit: Int = -1
+    ) async throws {}
+    
+    func addFileTorrent(
+        torrents: [String: Data],
+        savePath: String = "",
+        cookie: String = "",
+        category: String = "",
+        tags: String = "",
+        skipChecking: Bool = false,
+        paused: Bool = false,
+        sequentialDownload: Bool = false,
+        dlLimit: Int = -1,
+        upLimit: Int = -1,
+        ratioLimit: Float = -1.0,
+        seedingTimeLimit: Int = -1
+    ) async throws {}
+    
+    // MARK: - TorrentRSSActions
+    
+    func getRSSFeeds(withDate: Bool = true) async throws -> RSSNode {
+        return RSSNode()
+    }
+    
+    func addRSSFeed(url: String, path: String) async throws {}
+    func addRSSFolder(path: String) async throws {}
+    func addRSSRemoveItem(path: String) async throws {}
+    func addRSSRefreshItem(path: String) async throws {}
+    func moveRSSItem(itemPath: String, destPath: String) async throws {}
+    
+    // MARK: - TorrentCategoryTagActions
+    
+    func getCategories() async throws -> [String: Category] {
+        return ["Movies": Self.mockCategory]
+    }
+    
+    func setCategory(hash: String, category: String) async throws {}
+    
+    func addCategory(category: String, savePath: String?) async throws -> Int {
+        return 200
+    }
+    
+    func removeCategory(category: String) async throws -> Int {
+        return 200
+    }
+    
+    func getTags() async throws -> [String] {
+        return ["tag1", "tag2", "tag3"]
+    }
+    
+    func setTag(hash: String, tag: String) async throws -> Bool {
+        return true
+    }
+    
+    func unsetTag(hash: String, tag: String) async throws -> Bool {
+        return true
+    }
+    
+    func removeTag(tag: String) async throws -> Int {
+        return 200
+    }
+    
+    func addTag(tag: String) async throws -> Int {
+        return 200
+    }
+    
+    // MARK: - TorrentTrackerActions
+    
+    func getTrackers(hash: String) async throws -> [Tracker] {
+        return [Self.mockTracker]
+    }
+    
+    func addTrackerURL(hash: String, urls: String) async throws {}
+    func editTrackerURL(hash: String, origUrl: String, newURL: String) async throws {}
+    func removeTracker(hash: String, url: String) async throws {}
+    
+    // MARK: - TorrentSearchActions
+    
+    func getSearchStart(pattern: String, category: String, plugins: Bool = true) async throws -> SearchStartResult {
+        return SearchStartResult(id: 1)
+    }
+    
+    func getSearchResults(id: Int, limit: Int = 500, offset: Int = 0) async throws -> SearchResponse {
+        return SearchResponse(results: [], status: "Success", total: 0)
+    }
+    
+    func getSearchPlugins() async throws -> [SearchPlugin] {
+        return [Self.mockSearchPlugin]
+    }
+    
+    // MARK: - TorrentServerActions
+    
+    func fetchVersion() async throws -> Version {
+        return Self.mockVersion
+    }
+    
+    func getGlobalTransferInfo() async throws -> GlobalTransferInfo {
+        return Self.mockGlobalTransferInfo
+    }
+    
+    func getMainData(rid: Int = 0) async throws -> MainData {
+        return MainData(rid: rid, full_update: true, server_state: nil)
+    }
+    
+    func getPreferences() async throws -> qBitPreferences {
+        return Self.mockPreferences()
+    }
+}

--- a/qBitControl/Classes/TorrentClientProtocol.swift
+++ b/qBitControl/Classes/TorrentClientProtocol.swift
@@ -1,0 +1,115 @@
+//
+//  TorrentClientProtocol.swift
+//  qBitControl
+//
+
+import Foundation
+
+// MARK: - TorrentTaskActions
+protocol TorrentTaskActions {
+    func pauseTorrent(hash: String) async throws
+    func pauseTorrents(hashes: [String]) async throws
+    func pauseAllTorrents() async throws
+    
+    func resumeTorrent(hash: String) async throws
+    func resumeTorrents(hashes: [String]) async throws
+    func resumeAllTorrents() async throws
+    
+    func recheckTorrent(hash: String) async throws
+    func recheckTorrents(hashes: [String]) async throws
+    
+    func reannounceTorrent(hash: String) async throws
+    func reannounceTorrents(hashes: [String]) async throws
+    
+    func deleteTorrent(hash: String, deleteFiles: Bool) async throws
+    func deleteTorrents(hashes: [String], deleteFiles: Bool) async throws
+    
+    func increasePriorityTorrents(hashes: [String]) async throws
+    func decreasePriorityTorrents(hashes: [String]) async throws
+    func topPriorityTorrents(hashes: [String]) async throws
+    func bottomPriorityTorrents(hashes: [String]) async throws
+    
+    func toggleSequentialDownload(hashes: [String]) async throws
+    func toggleFLPiecesFirst(hashes: [String]) async throws
+    func setForceStart(hashes: [String], value: Bool) async throws
+    
+    func addMagnetTorrent(
+        torrent: URLQueryItem,
+        savePath: String,
+        cookie: String,
+        category: String,
+        tags: String,
+        skipChecking: Bool,
+        paused: Bool,
+        sequentialDownload: Bool,
+        dlLimit: Int,
+        upLimit: Int,
+        ratioLimit: Float,
+        seedingTimeLimit: Int
+    ) async throws
+    
+    func addFileTorrent(
+        torrents: [String: Data],
+        savePath: String,
+        cookie: String,
+        category: String,
+        tags: String,
+        skipChecking: Bool,
+        paused: Bool,
+        sequentialDownload: Bool,
+        dlLimit: Int,
+        upLimit: Int,
+        ratioLimit: Float,
+        seedingTimeLimit: Int
+    ) async throws
+}
+
+// MARK: - TorrentRSSActions
+protocol TorrentRSSActions {
+    func getRSSFeeds(withDate: Bool) async throws -> RSSNode
+    func addRSSFeed(url: String, path: String) async throws
+    func addRSSFolder(path: String) async throws
+    func addRSSRemoveItem(path: String) async throws
+    func addRSSRefreshItem(path: String) async throws
+    func moveRSSItem(itemPath: String, destPath: String) async throws
+}
+
+// MARK: - TorrentCategoryTagActions
+protocol TorrentCategoryTagActions {
+    func getCategories() async throws -> [String: Category]
+    func setCategory(hash: String, category: String) async throws
+    func addCategory(category: String, savePath: String?) async throws -> Int
+    func removeCategory(category: String) async throws -> Int
+    
+    func getTags() async throws -> [String]
+    func setTag(hash: String, tag: String) async throws -> Bool
+    func unsetTag(hash: String, tag: String) async throws -> Bool
+    func removeTag(tag: String) async throws -> Int
+    func addTag(tag: String) async throws -> Int
+}
+
+// MARK: - TorrentTrackerActions
+protocol TorrentTrackerActions {
+    func getTrackers(hash: String) async throws -> [Tracker]
+    func addTrackerURL(hash: String, urls: String) async throws
+    func editTrackerURL(hash: String, origUrl: String, newURL: String) async throws
+    func removeTracker(hash: String, url: String) async throws
+}
+
+// MARK: - TorrentSearchActions
+protocol TorrentSearchActions {
+    func getSearchStart(pattern: String, category: String, plugins: Bool) async throws -> SearchStartResult
+    func getSearchResults(id: Int, limit: Int, offset: Int) async throws -> SearchResponse
+    func getSearchPlugins() async throws -> [SearchPlugin]
+}
+
+// MARK: - TorrentServerActions
+protocol TorrentServerActions {
+    func fetchVersion() async throws -> Version
+    func getGlobalTransferInfo() async throws -> GlobalTransferInfo
+    func getMainData(rid: Int) async throws -> MainData
+    func getPreferences() async throws -> qBitPreferences
+}
+
+// MARK: - TorrentClientProtocol
+typealias TorrentClientProtocol = TorrentTaskActions & TorrentRSSActions & TorrentCategoryTagActions & TorrentTrackerActions & TorrentSearchActions & TorrentServerActions

--- a/qBitControl/Classes/qBittorrentClient.swift
+++ b/qBitControl/Classes/qBittorrentClient.swift
@@ -1,0 +1,244 @@
+//
+//  qBittorrentClient.swift
+//  qBitControl
+//
+
+import Foundation
+
+class qBittorrentClient: TorrentClientProtocol {
+    private let networkClient: NetworkClient
+    
+    enum ClientError: Error {
+        case notImplemented
+    }
+    
+    init(networkClient: NetworkClient) {
+        self.networkClient = networkClient
+    }
+    
+    // MARK: - TorrentTaskActions
+    
+    func pauseTorrent(hash: String) async throws {
+        throw ClientError.notImplemented
+    }
+    
+    func pauseTorrents(hashes: [String]) async throws {
+        throw ClientError.notImplemented
+    }
+    
+    func pauseAllTorrents() async throws {
+        throw ClientError.notImplemented
+    }
+    
+    func resumeTorrent(hash: String) async throws {
+        throw ClientError.notImplemented
+    }
+    
+    func resumeTorrents(hashes: [String]) async throws {
+        throw ClientError.notImplemented
+    }
+    
+    func resumeAllTorrents() async throws {
+        throw ClientError.notImplemented
+    }
+    
+    func recheckTorrent(hash: String) async throws {
+        throw ClientError.notImplemented
+    }
+    
+    func recheckTorrents(hashes: [String]) async throws {
+        throw ClientError.notImplemented
+    }
+    
+    func reannounceTorrent(hash: String) async throws {
+        throw ClientError.notImplemented
+    }
+    
+    func reannounceTorrents(hashes: [String]) async throws {
+        throw ClientError.notImplemented
+    }
+    
+    func deleteTorrent(hash: String, deleteFiles: Bool) async throws {
+        throw ClientError.notImplemented
+    }
+    
+    func deleteTorrents(hashes: [String], deleteFiles: Bool) async throws {
+        throw ClientError.notImplemented
+    }
+    
+    func increasePriorityTorrents(hashes: [String]) async throws {
+        throw ClientError.notImplemented
+    }
+    
+    func decreasePriorityTorrents(hashes: [String]) async throws {
+        throw ClientError.notImplemented
+    }
+    
+    func topPriorityTorrents(hashes: [String]) async throws {
+        throw ClientError.notImplemented
+    }
+    
+    func bottomPriorityTorrents(hashes: [String]) async throws {
+        throw ClientError.notImplemented
+    }
+    
+    func toggleSequentialDownload(hashes: [String]) async throws {
+        throw ClientError.notImplemented
+    }
+    
+    func toggleFLPiecesFirst(hashes: [String]) async throws {
+        throw ClientError.notImplemented
+    }
+    
+    func setForceStart(hashes: [String], value: Bool) async throws {
+        throw ClientError.notImplemented
+    }
+    
+    func addMagnetTorrent(
+        torrent: URLQueryItem,
+        savePath: String = "",
+        cookie: String = "",
+        category: String = "",
+        tags: String = "",
+        skipChecking: Bool = false,
+        paused: Bool = false,
+        sequentialDownload: Bool = false,
+        dlLimit: Int = -1,
+        upLimit: Int = -1,
+        ratioLimit: Float = -1.0,
+        seedingTimeLimit: Int = -1
+    ) async throws {
+        throw ClientError.notImplemented
+    }
+    
+    func addFileTorrent(
+        torrents: [String: Data],
+        savePath: String = "",
+        cookie: String = "",
+        category: String = "",
+        tags: String = "",
+        skipChecking: Bool = false,
+        paused: Bool = false,
+        sequentialDownload: Bool = false,
+        dlLimit: Int = -1,
+        upLimit: Int = -1,
+        ratioLimit: Float = -1.0,
+        seedingTimeLimit: Int = -1
+    ) async throws {
+        throw ClientError.notImplemented
+    }
+    
+    // MARK: - TorrentRSSActions
+    
+    func getRSSFeeds(withDate: Bool = true) async throws -> RSSNode {
+        throw ClientError.notImplemented
+    }
+    
+    func addRSSFeed(url: String, path: String) async throws {
+        throw ClientError.notImplemented
+    }
+    
+    func addRSSFolder(path: String) async throws {
+        throw ClientError.notImplemented
+    }
+    
+    func addRSSRemoveItem(path: String) async throws {
+        throw ClientError.notImplemented
+    }
+    
+    func addRSSRefreshItem(path: String) async throws {
+        throw ClientError.notImplemented
+    }
+    
+    func moveRSSItem(itemPath: String, destPath: String) async throws {
+        throw ClientError.notImplemented
+    }
+    
+    // MARK: - TorrentCategoryTagActions
+    
+    func getCategories() async throws -> [String: Category] {
+        throw ClientError.notImplemented
+    }
+    
+    func setCategory(hash: String, category: String) async throws {
+        throw ClientError.notImplemented
+    }
+    
+    func addCategory(category: String, savePath: String?) async throws -> Int {
+        throw ClientError.notImplemented
+    }
+    
+    func removeCategory(category: String) async throws -> Int {
+        throw ClientError.notImplemented
+    }
+    
+    func getTags() async throws -> [String] {
+        throw ClientError.notImplemented
+    }
+    
+    func setTag(hash: String, tag: String) async throws -> Bool {
+        throw ClientError.notImplemented
+    }
+    
+    func unsetTag(hash: String, tag: String) async throws -> Bool {
+        throw ClientError.notImplemented
+    }
+    
+    func removeTag(tag: String) async throws -> Int {
+        throw ClientError.notImplemented
+    }
+    
+    func addTag(tag: String) async throws -> Int {
+        throw ClientError.notImplemented
+    }
+    
+    // MARK: - TorrentTrackerActions
+    
+    func getTrackers(hash: String) async throws -> [Tracker] {
+        throw ClientError.notImplemented
+    }
+    
+    func addTrackerURL(hash: String, urls: String) async throws {
+        throw ClientError.notImplemented
+    }
+    
+    func editTrackerURL(hash: String, origUrl: String, newURL: String) async throws {
+        throw ClientError.notImplemented
+    }
+    
+    func removeTracker(hash: String, url: String) async throws {
+        throw ClientError.notImplemented
+    }
+    
+    // MARK: - TorrentSearchActions
+    
+    func getSearchStart(pattern: String, category: String, plugins: Bool = true) async throws -> SearchStartResult {
+        throw ClientError.notImplemented
+    }
+    
+    func getSearchResults(id: Int, limit: Int = 500, offset: Int = 0) async throws -> SearchResponse {
+        throw ClientError.notImplemented
+    }
+    
+    func getSearchPlugins() async throws -> [SearchPlugin] {
+        throw ClientError.notImplemented
+    }
+    
+    // MARK: - TorrentServerActions
+    
+    func fetchVersion() async throws -> Version {
+        throw ClientError.notImplemented
+    }
+    
+    func getGlobalTransferInfo() async throws -> GlobalTransferInfo {
+        throw ClientError.notImplemented
+    }
+    
+    func getMainData(rid: Int = 0) async throws -> MainData {
+        throw ClientError.notImplemented
+    }
+    
+    func getPreferences() async throws -> qBitPreferences {
+        throw ClientError.notImplemented
+    }
+}


### PR DESCRIPTION
## Description
- Define sub-protocols for task, RSS, category/tag, tracker, search, and server actions
- Add typealias TorrentClientProtocol composing all actions
- Implement production qBittorrentClient with NetworkClient property
- Implement MockTorrentClient with static mock data for previews and tests
- Update project.pbxproj to compile the new files

## Related Issues (Optional)
Related: #98 
