### PR TITLE
feat(torrent-list): migrate view and view model to TorrentClientProtocol

### DIFF
--- a/qBitControl/Classes/MockTorrentClient.swift
+++ b/qBitControl/Classes/MockTorrentClient.swift
@@ -49,9 +49,121 @@ class MockTorrentClient: TorrentClientProtocol {
         return try! JSONDecoder().decode(qBitPreferences.self, from: json.data(using: .utf8)!)
     }
     
+    static let mockTorrents: [Torrent] = {
+        let json = """
+        [
+            {
+                "added_on": 1682347623,
+                "amount_left": 0,
+                "auto_tmm": false,
+                "availability": 1.0,
+                "category": "Movies",
+                "completed": 1000000000,
+                "completion_on": 1682348000,
+                "content_path": "/Downloads/Movies/ubuntu.iso",
+                "dl_limit": -1,
+                "dlspeed": 0,
+                "downloaded": 1000000000,
+                "downloaded_session": 1000000000,
+                "eta": 8640000,
+                "f_l_piece_prio": false,
+                "force_start": false,
+                "hash": "1a2b3c4d5e6f7g8h9i0j",
+                "last_activity": 1682348000,
+                "magnet_uri": "magnet:?xt=urn:btih:1a2b3c4d5e6f7g8h9i0j",
+                "max_ratio": -1.0,
+                "max_seeding_time": -1,
+                "name": "Ubuntu 22.04 LTS Desktop",
+                "num_complete": 150,
+                "num_incomplete": 5,
+                "num_leechs": 5,
+                "num_seeds": 150,
+                "priority": 1,
+                "progress": 1.0,
+                "ratio": 1.5,
+                "ratio_limit": -1.0,
+                "save_path": "/Downloads/Movies",
+                "seeding_time": 3600,
+                "seeding_time_limit": -1,
+                "seen_complete": 1682348000,
+                "seq_dl": false,
+                "size": 1000000000,
+                "state": "seeding",
+                "super_seeding": false,
+                "tags": "linux,os",
+                "time_active": 7200,
+                "total_size": 1000000000,
+                "tracker": "udp://tracker.opentrackr.org:1337/announce",
+                "up_limit": -1,
+                "uploaded": 1500000000,
+                "uploaded_session": 1500000000,
+                "upspeed": 512000
+            },
+            {
+                "added_on": 1682349000,
+                "amount_left": 500000000,
+                "auto_tmm": false,
+                "availability": 0.8,
+                "category": "All",
+                "completed": 500000000,
+                "completion_on": 0,
+                "content_path": "/Downloads/debian.iso",
+                "dl_limit": -1,
+                "dlspeed": 1024000,
+                "downloaded": 500000000,
+                "downloaded_session": 500000000,
+                "eta": 488,
+                "f_l_piece_prio": false,
+                "force_start": false,
+                "hash": "2b3c4d5e6f7g8h9i0j1a",
+                "last_activity": 1682349500,
+                "magnet_uri": "magnet:?xt=urn:btih:2b3c4d5e6f7g8h9i0j1a",
+                "max_ratio": -1.0,
+                "max_seeding_time": -1,
+                "name": "Debian GNU/Linux 12 NetInstall",
+                "num_complete": 80,
+                "num_incomplete": 12,
+                "num_leechs": 12,
+                "num_seeds": 80,
+                "priority": 2,
+                "progress": 0.5,
+                "ratio": 0.0,
+                "ratio_limit": -1.0,
+                "save_path": "/Downloads",
+                "seeding_time": 0,
+                "seeding_time_limit": -1,
+                "seen_complete": 0,
+                "seq_dl": false,
+                "size": 1000000000,
+                "state": "downloading",
+                "super_seeding": false,
+                "tags": "linux,debian",
+                "time_active": 500,
+                "total_size": 1000000000,
+                "tracker": "udp://tracker.opentrackr.org:1337/announce",
+                "up_limit": -1,
+                "uploaded": 0,
+                "uploaded_session": 0,
+                "upspeed": 0
+            }
+        ]
+        """
+        return try! JSONDecoder().decode([Torrent].self, from: json.data(using: .utf8)!)
+    }()
+    
     init() {}
     
     // MARK: - TorrentTaskActions
+    
+    func fetchTorrents(
+        filter: String?,
+        category: String?,
+        tag: String?,
+        sort: String?,
+        reverse: Bool?
+    ) async throws -> [Torrent] {
+        return Self.mockTorrents
+    }
     
     func pauseTorrent(hash: String) async throws {}
     func pauseTorrents(hashes: [String]) async throws {}

--- a/qBitControl/Classes/TorrentClientProtocol.swift
+++ b/qBitControl/Classes/TorrentClientProtocol.swift
@@ -7,6 +7,14 @@ import Foundation
 
 // MARK: - TorrentTaskActions
 protocol TorrentTaskActions {
+    func fetchTorrents(
+        filter: String?,
+        category: String?,
+        tag: String?,
+        sort: String?,
+        reverse: Bool?
+    ) async throws -> [Torrent]
+    
     func pauseTorrent(hash: String) async throws
     func pauseTorrents(hashes: [String]) async throws
     func pauseAllTorrents() async throws
@@ -114,3 +122,15 @@ protocol TorrentServerActions {
 
 // MARK: - TorrentClientProtocol
 typealias TorrentClientProtocol = TorrentTaskActions & TorrentRSSActions & TorrentCategoryTagActions & TorrentTrackerActions & TorrentSearchActions & TorrentServerActions
+
+extension TorrentTaskActions {
+    func fetchTorrents(
+        filter: String? = nil,
+        category: String? = nil,
+        tag: String? = nil,
+        sort: String? = nil,
+        reverse: Bool? = nil
+    ) async throws -> [Torrent] {
+        try await fetchTorrents(filter: filter, category: category, tag: tag, sort: sort, reverse: reverse)
+    }
+}

--- a/qBitControl/Classes/qBittorrentClient.swift
+++ b/qBitControl/Classes/qBittorrentClient.swift
@@ -20,6 +20,23 @@ class qBittorrentClient: TorrentClientProtocol {
     
     // MARK: - TorrentTaskActions
     
+    func fetchTorrents(
+        filter: String?,
+        category: String?,
+        tag: String?,
+        sort: String?,
+        reverse: Bool?
+    ) async throws -> [Torrent] {
+        var queryItems: [URLQueryItem] = []
+        if let filter = filter { queryItems.append(URLQueryItem(name: "filter", value: filter)) }
+        if let category = category { queryItems.append(URLQueryItem(name: "category", value: category)) }
+        if let tag = tag { queryItems.append(URLQueryItem(name: "tag", value: tag)) }
+        if let sort = sort { queryItems.append(URLQueryItem(name: "sort", value: sort)) }
+        if let reverse = reverse { queryItems.append(URLQueryItem(name: "reverse", value: String(reverse))) }
+        
+        return try await networkClient.sendRequest(path: "/api/v2/torrents/info", queryItems: queryItems, cookie: self.cookie)
+    }
+    
     func pauseTorrent(hash: String) async throws {
         throw ClientError.notImplemented
     }

--- a/qBitControl/ViewModels/TorrentView/TorrentListHelperViewModel.swift
+++ b/qBitControl/ViewModels/TorrentView/TorrentListHelperViewModel.swift
@@ -1,8 +1,14 @@
 //
+//  TorrentListHelperViewModel.swift
+//  qBitControl
+//
+
 import SwiftUI
 
+@MainActor
 class TorrentListHelperViewModel: ObservableObject {
     let defaults = UserDefaults.standard
+    private let client: TorrentClientProtocol
     
     @Published public var torrents: [Torrent] = []
     
@@ -29,7 +35,7 @@ class TorrentListHelperViewModel: ObservableObject {
     @Published var alertIdentifier: AlertIdentifier?
     @Published var sheetIdentifier: SheetIdentifier?
     
-    var timer: Timer?
+    private var pollingTask: Task<Void, Never>?
     var hash = ""
     
     public var categoryName: String {
@@ -39,27 +45,33 @@ class TorrentListHelperViewModel: ObservableObject {
         return category.capitalized
     }
     
-    init() {}
+    init(client: TorrentClientProtocol) {
+        self.client = client
+    }
     
-    func getTorrents() {
+    func getTorrents() async {
         if(scenePhase != .active || isTorrentAddView || isSelectionMode) { return }
         
-        var queryItems = [URLQueryItem(name: "sort", value: sort), URLQueryItem(name: "filter", value: filter), URLQueryItem(name: "reverse", value: String(reverse))]
-        
-        if category != "All" { queryItems.append(URLQueryItem(name: "category", value: category)) }
-        if tag != "All" { queryItems.append(URLQueryItem(name: "tag", value: tag)) }
-        
-        let request = qBitRequest.prepareURLRequest(path: "/api/v2/torrents/info", queryItems: queryItems)
-        
-        qBitRequest.requestTorrentListJSON(request: request) {
-            _torrents in
+        do {
+            let catParam = category == "All" ? nil : category
+            let tagParam = tag == "All" ? nil : tag
             
-            DispatchQueue.main.async {
-                if(self.sort == "priority") { self.torrents = self.getTorrentsSortedByPriority(torrents: _torrents) }
-                else { self.torrents = _torrents }
-                
-                self.filteredTorrents = self.getFilteredTorrents(torrents: self.torrents)
+            let _torrents = try await client.fetchTorrents(
+                filter: filter,
+                category: catParam,
+                tag: tagParam,
+                sort: sort,
+                reverse: reverse
+            )
+            
+            if self.sort == "priority" {
+                self.torrents = self.getTorrentsSortedByPriority(torrents: _torrents)
+            } else {
+                self.torrents = _torrents
             }
+            self.filteredTorrents = self.getFilteredTorrents(torrents: self.torrents)
+        } catch {
+            print("Failed to fetch torrents: \(error)")
         }
     }
     
@@ -70,11 +82,11 @@ class TorrentListHelperViewModel: ObservableObject {
             if(reverse) {
                 if(tor2.priority <= 0) { return false }
                 if(tor1.priority < tor2.priority) { return false }
-                return true;
+                return true
             } else {
                 if(tor2.priority <= 0) { return true }
-                if(tor1.priority < tor2.priority) { return true; }
-                return false;
+                if(tor1.priority < tor2.priority) { return true }
+                return false
             }
         })
     }
@@ -84,15 +96,32 @@ class TorrentListHelperViewModel: ObservableObject {
         return torrents.filter { torrent in torrent.name.lowercased().contains(searchQuery.lowercased()) }
     }
     
-    func startTimer() {
-        timer = Timer.scheduledTimer(withTimeInterval: 2, repeats: true) {
-            timer in
-            self.getTorrents()
+    func startPolling() {
+        pollingTask?.cancel()
+        pollingTask = Task {
+            while !Task.isCancelled {
+                await getTorrents()
+                do {
+                    // Sleep for 2 seconds (2,000,000,000 nanoseconds)
+                    try await Task.sleep(nanoseconds: 2_000_000_000)
+                } catch {
+                    break
+                }
+            }
         }
     }
     
+    func stopPolling() {
+        pollingTask?.cancel()
+        pollingTask = nil
+    }
+    
+    func startTimer() {
+        startPolling()
+    }
+    
     func stopTimer() {
-        timer?.invalidate()
+        stopPolling()
     }
     
     func getInitialTorrents() {
@@ -100,9 +129,7 @@ class TorrentListHelperViewModel: ObservableObject {
         sort = defaults.string(forKey: "sort") ?? sort
         filter = defaults.string(forKey: "filter") ?? filter
         
-        getTorrents()
-        
-        startTimer()
+        startPolling()
     }
     
     func deleteTorrent(torrent: Torrent) {
@@ -142,31 +169,61 @@ class TorrentListHelperViewModel: ObservableObject {
     
     func resumeSelectedTorrents() {
         self.doForSelectedTorrents { hashes in
-            qBittorrent.resumeTorrents(hashes: hashes)
+            Task {
+                do {
+                    try await client.resumeTorrents(hashes: hashes)
+                } catch {
+                    print("Failed to resume torrents: \(error)")
+                }
+            }
         }
     }
     
     func pauseSelectedTorrents() {
         self.doForSelectedTorrents { hashes in
-            qBittorrent.pauseTorrents(hashes: hashes)
+            Task {
+                do {
+                    try await client.pauseTorrents(hashes: hashes)
+                } catch {
+                    print("Failed to pause torrents: \(error)")
+                }
+            }
         }
     }
     
     func deleteSelectedTorrents(isDeleteFiles: Bool = false) {
         self.doForSelectedTorrents { hashes in
-            qBittorrent.deleteTorrents(hashes: hashes, deleteFiles: isDeleteFiles)
+            Task {
+                do {
+                    try await client.deleteTorrents(hashes: hashes, deleteFiles: isDeleteFiles)
+                } catch {
+                    print("Failed to delete torrents: \(error)")
+                }
+            }
         }
     }
     
     func recheckSelectedTorrents() {
         self.doForSelectedTorrents { hashes in
-            qBittorrent.recheckTorrents(hashes: hashes)
+            Task {
+                do {
+                    try await client.recheckTorrents(hashes: hashes)
+                } catch {
+                    print("Failed to recheck torrents: \(error)")
+                }
+            }
         }
     }
     
     func reannounceSelectedTorrents() {
         self.doForSelectedTorrents { hashes in
-            qBittorrent.reannounceTorrents(hashes: hashes)
+            Task {
+                do {
+                    try await client.reannounceTorrents(hashes: hashes)
+                } catch {
+                    print("Failed to reannounce torrents: \(error)")
+                }
+            }
         }
     }
     
@@ -190,13 +247,25 @@ class TorrentListHelperViewModel: ObservableObject {
     
     func resumeCurrentCategoryTorrents() {
         self.doForTorrentsInCategory { hashes in
-            qBittorrent.resumeTorrents(hashes: hashes)
+            Task {
+                do {
+                    try await client.resumeTorrents(hashes: hashes)
+                } catch {
+                    print("Failed to resume category torrents: \(error)")
+                }
+            }
         }
     }
     
     func pauseCurrentCategoryTorrents() {
         self.doForTorrentsInCategory { hashes in
-            qBittorrent.pauseTorrents(hashes: hashes)
+            Task {
+                do {
+                    try await client.pauseTorrents(hashes: hashes)
+                } catch {
+                    print("Failed to pause category torrents: \(error)")
+                }
+            }
         }
     }
     
@@ -204,6 +273,12 @@ class TorrentListHelperViewModel: ObservableObject {
         let completedTorrents = torrents.filter {torrent in torrent.progress == 1}
         let completedHashes = completedTorrents.compactMap {torrent in torrent.hash}
         
-        qBittorrent.deleteTorrents(hashes: completedHashes, deleteFiles: isDeleteFiles)
+        Task {
+            do {
+                try await client.deleteTorrents(hashes: completedHashes, deleteFiles: isDeleteFiles)
+            } catch {
+                print("Failed to delete completed torrents: \(error)")
+            }
+        }
     }
 }

--- a/qBitControl/ViewModels/TorrentView/TorrentListViewModel.swift
+++ b/qBitControl/ViewModels/TorrentView/TorrentListViewModel.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 
+@MainActor
 class TorrentListViewModel: ObservableObject {
     @ObservedObject private var torrentListHelperViewModel: TorrentListHelperViewModel
     

--- a/qBitControl/Views/TorrentViews/TorrentListView.swift
+++ b/qBitControl/Views/TorrentViews/TorrentListView.swift
@@ -7,8 +7,13 @@ import SwiftUI
 
     
 struct TorrentListView: View {
-    @StateObject var torrentListHelperViewModel: TorrentListHelperViewModel = .init()
+    @StateObject var torrentListHelperViewModel: TorrentListHelperViewModel
     @State private var torrentUrls: [URL] = []
+    
+    init() {
+        let client = ServersHelper.shared.client ?? MockTorrentClient()
+        _torrentListHelperViewModel = StateObject(wrappedValue: TorrentListHelperViewModel(client: client))
+    }
     
     func openUrl(url: URL) {
         if url.absoluteString.contains("file") || url.absoluteString.contains("magnet") {


### PR DESCRIPTION
## Description
- Implement fetchTorrents in qBittorrentClient and MockTorrentClient
- Decorate TorrentListHelperViewModel and TorrentListViewModel with `@MainActor` for thread safety
- Update TorrentListHelperViewModel to accept TorrentClientProtocol via initializer
- Replace rigid Timer with a sequential Task loop using Task.sleep to prevent request piling
- Inject client dependency from ServersHelper into TorrentListHelperViewModel via TorrentListView init

## Related Issues (Optional)
Related: #98 