### PR TITLE
feat(add-rss-search): migrate torrent additions, RSS feeds and search engine to new client

### DIFF
--- a/qBitControl/Classes/NetworkClient.swift
+++ b/qBitControl/Classes/NetworkClient.swift
@@ -147,4 +147,119 @@ actor NetworkClient {
         let (decoded, _): (T, HTTPURLResponse) = try await sendRequestWithResponse(path: path, queryItems: queryItems, cookie: cookie)
         return decoded
     }
+
+    /// Uploads files using multipart/form-data asynchronously without loading massive files entirely into memory.
+    func uploadMultipart<T: Decodable>(
+        path: String,
+        files: [String: Data],
+        params: [String: String],
+        cookie: String?
+    ) async throws -> T {
+        guard let url = URL(string: "\(baseURL)\(path)") else {
+            throw NetworkError.invalidURL
+        }
+
+        let boundary = "Boundary-\(UUID().uuidString.replacingOccurrences(of: "-", with: ""))"
+        let fileURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        
+        FileManager.default.createFile(atPath: fileURL.path, contents: nil, attributes: nil)
+        let fileHandle = try FileHandle(forWritingTo: fileURL)
+
+        // 1. Write params
+        for (name, value) in params {
+            let paramStr = "--\(boundary)\r\nContent-Disposition: form-data; name=\"\(name)\"\r\n\r\n\(value)\r\n"
+            if let paramData = paramStr.data(using: .utf8) {
+                fileHandle.write(paramData)
+            }
+        }
+
+        // 2. Write files
+        for (fileName, fileData) in files {
+            let header = "--\(boundary)\r\nContent-Disposition: form-data; name=\"torrents\"; filename=\"\(fileName)\"\r\nContent-Type: application/x-bittorrent\r\n\r\n"
+            if let headerData = header.data(using: .utf8) {
+                fileHandle.write(headerData)
+            }
+            fileHandle.write(fileData)
+            if let boundaryEndData = "\r\n".data(using: .utf8) {
+                fileHandle.write(boundaryEndData)
+            }
+        }
+
+        // 3. Write footer
+        let footer = "--\(boundary)--\r\n"
+        if let footerData = footer.data(using: .utf8) {
+            fileHandle.write(footerData)
+        }
+        
+        if #available(macOS 10.15, iOS 13.0, *) {
+            try fileHandle.close()
+        } else {
+            fileHandle.closeFile()
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
+
+        // 4. Configure headers: Basic Auth and Cookies
+        if let basicAuth = basicAuth {
+            request.setValue("Basic \(basicAuth.getAuthString())", forHTTPHeaderField: "Authorization")
+        }
+
+        if let cookie = cookie {
+            request.setValue(cookie, forHTTPHeaderField: "Cookie")
+        }
+
+        // 5. Execute upload
+        let data: Data
+        let response: URLResponse
+        do {
+            if #available(macOS 12.0, iOS 15.0, *) {
+                (data, response) = try await session.upload(for: request, fromFile: fileURL)
+            } else {
+                (data, response) = try await withCheckedThrowingContinuation { continuation in
+                    let task = session.uploadTask(with: request, fromFile: fileURL) { data, response, error in
+                        if let error = error {
+                            continuation.resume(throwing: error)
+                        } else if let data = data, let response = response {
+                            continuation.resume(returning: (data, response))
+                        } else {
+                            continuation.resume(throwing: URLError(.unknown))
+                        }
+                    }
+                    task.resume()
+                }
+            }
+        } catch {
+            try? FileManager.default.removeItem(at: fileURL)
+            throw error
+        }
+
+        try? FileManager.default.removeItem(at: fileURL)
+
+        // 6. Handle HTTP response and status codes
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw NetworkError.invalidResponse
+        }
+
+        let statusCode = httpResponse.statusCode
+        if statusCode == 401 || statusCode == 403 {
+            throw NetworkError.unauthorized
+        }
+        guard (200...299).contains(statusCode) else {
+            throw NetworkError.httpError(statusCode: statusCode)
+        }
+
+        // 7. Decode response (specifically handle raw String fallback if T is String)
+        if T.self == String.self {
+            if let decoded = try? JSONDecoder().decode(T.self, from: data) {
+                return decoded
+            }
+            if let rawString = String(data: data, encoding: .utf8) as? T {
+                return rawString
+            }
+        }
+
+        return try JSONDecoder().decode(T.self, from: data)
+    }
 }

--- a/qBitControl/Classes/qBittorrentClient.swift
+++ b/qBitControl/Classes/qBittorrentClient.swift
@@ -220,7 +220,23 @@ class qBittorrentClient: TorrentClientProtocol {
         ratioLimit: Float = -1.0,
         seedingTimeLimit: Int = -1
     ) async throws {
-        throw ClientError.notImplemented
+        var queryItems: [URLQueryItem] = [torrent]
+        if savePath != "" { queryItems.append(URLQueryItem(name: "savepath", value: savePath)) }
+        if cookie != "" { queryItems.append(URLQueryItem(name: "cookie", value: cookie)) }
+        if category != "" { queryItems.append(URLQueryItem(name: "category", value: category)) }
+        if tags != "" { queryItems.append(URLQueryItem(name: "tags", value: tags)) }
+        if skipChecking { queryItems.append(URLQueryItem(name: "skip_checking", value: "true")) }
+        if paused {
+            let suffix = self.version.major == 5 ? "stopped" : "paused"
+            queryItems.append(URLQueryItem(name: suffix, value: "true"))
+        }
+        if dlLimit > 0 { queryItems.append(URLQueryItem(name: "dlLimit", value: "\(dlLimit)")) }
+        if upLimit > 0 { queryItems.append(URLQueryItem(name: "upLimit", value: "\(upLimit)")) }
+        if ratioLimit > 0 { queryItems.append(URLQueryItem(name: "ratioLimit", value: "\(ratioLimit)")) }
+        if seedingTimeLimit > 0 { queryItems.append(URLQueryItem(name: "seedingTimeLimit", value: "\(seedingTimeLimit)")) }
+        if sequentialDownload { queryItems.append(URLQueryItem(name: "sequentialDownload", value: "true")) }
+        
+        let _: String = try await networkClient.sendRequest(path: "/api/v2/torrents/add", queryItems: queryItems, cookie: self.cookie)
     }
     
     func addFileTorrent(
@@ -237,7 +253,28 @@ class qBittorrentClient: TorrentClientProtocol {
         ratioLimit: Float = -1.0,
         seedingTimeLimit: Int = -1
     ) async throws {
-        throw ClientError.notImplemented
+        var params: [String: String] = [:]
+        if savePath != "" { params["savepath"] = savePath }
+        if cookie != "" { params["cookie"] = cookie }
+        if category != "" { params["category"] = category }
+        if tags != "" { params["tags"] = tags }
+        if skipChecking { params["skip_checking"] = "true" }
+        if paused {
+            let suffix = self.version.major == 5 ? "stopped" : "paused"
+            params[suffix] = "true"
+        }
+        if dlLimit > 0 { params["dlLimit"] = "\(dlLimit)" }
+        if upLimit > 0 { params["upLimit"] = "\(upLimit)" }
+        if ratioLimit > 0 { params["ratioLimit"] = "\(ratioLimit)" }
+        if seedingTimeLimit > 0 { params["seedingTimeLimit"] = "\(seedingTimeLimit)" }
+        if sequentialDownload { params["sequentialDownload"] = "true" }
+
+        let _: String = try await networkClient.uploadMultipart(
+            path: "/api/v2/torrents/add",
+            files: torrents,
+            params: params,
+            cookie: self.cookie
+        )
     }
     
     func getFiles(hash: String) async throws -> [File] {
@@ -263,27 +300,57 @@ class qBittorrentClient: TorrentClientProtocol {
     // MARK: - TorrentRSSActions
     
     func getRSSFeeds(withDate: Bool = true) async throws -> RSSNode {
-        throw ClientError.notImplemented
+        return try await networkClient.sendRequest(
+            path: "/api/v2/rss/items",
+            queryItems: [URLQueryItem(name: "withData", value: String(withDate))],
+            cookie: self.cookie
+        )
     }
     
     func addRSSFeed(url: String, path: String) async throws {
-        throw ClientError.notImplemented
+        let _: String = try await networkClient.sendRequest(
+            path: "/api/v2/rss/addFeed",
+            queryItems: [
+                URLQueryItem(name: "url", value: url),
+                URLQueryItem(name: "path", value: path)
+            ],
+            cookie: self.cookie
+        )
     }
     
     func addRSSFolder(path: String) async throws {
-        throw ClientError.notImplemented
+        let _: String = try await networkClient.sendRequest(
+            path: "/api/v2/rss/addFolder",
+            queryItems: [URLQueryItem(name: "path", value: path)],
+            cookie: self.cookie
+        )
     }
     
     func addRSSRemoveItem(path: String) async throws {
-        throw ClientError.notImplemented
+        let _: String = try await networkClient.sendRequest(
+            path: "/api/v2/rss/removeItem",
+            queryItems: [URLQueryItem(name: "path", value: path)],
+            cookie: self.cookie
+        )
     }
     
     func addRSSRefreshItem(path: String) async throws {
-        throw ClientError.notImplemented
+        let _: String = try await networkClient.sendRequest(
+            path: "/api/v2/rss/refreshItem",
+            queryItems: [URLQueryItem(name: "path", value: path)],
+            cookie: self.cookie
+        )
     }
     
     func moveRSSItem(itemPath: String, destPath: String) async throws {
-        throw ClientError.notImplemented
+        let _: String = try await networkClient.sendRequest(
+            path: "/api/v2/rss/moveItem",
+            queryItems: [
+                URLQueryItem(name: "itemPath", value: itemPath),
+                URLQueryItem(name: "destPath", value: destPath)
+            ],
+            cookie: self.cookie
+        )
     }
     
     // MARK: - TorrentCategoryTagActions
@@ -371,15 +438,35 @@ class qBittorrentClient: TorrentClientProtocol {
     // MARK: - TorrentSearchActions
     
     func getSearchStart(pattern: String, category: String, plugins: Bool = true) async throws -> SearchStartResult {
-        throw ClientError.notImplemented
+        return try await networkClient.sendRequest(
+            path: "/api/v2/search/start",
+            queryItems: [
+                URLQueryItem(name: "pattern", value: pattern),
+                URLQueryItem(name: "category", value: category),
+                URLQueryItem(name: "plugins", value: String(plugins))
+            ],
+            cookie: self.cookie
+        )
     }
     
     func getSearchResults(id: Int, limit: Int = 500, offset: Int = 0) async throws -> SearchResponse {
-        throw ClientError.notImplemented
+        return try await networkClient.sendRequest(
+            path: "/api/v2/search/results",
+            queryItems: [
+                URLQueryItem(name: "id", value: String(id)),
+                URLQueryItem(name: "limit", value: String(limit)),
+                URLQueryItem(name: "offset", value: String(offset))
+            ],
+            cookie: self.cookie
+        )
     }
     
     func getSearchPlugins() async throws -> [SearchPlugin] {
-        throw ClientError.notImplemented
+        return try await networkClient.sendRequest(
+            path: "/api/v2/search/plugins",
+            queryItems: [],
+            cookie: self.cookie
+        )
     }
     
     // MARK: - TorrentServerActions

--- a/qBitControl/ViewModels/RSSView/RSSNodeViewModel.swift
+++ b/qBitControl/ViewModels/RSSView/RSSNodeViewModel.swift
@@ -1,29 +1,59 @@
+//
+//  RSSNodeViewModel.swift
+//  qBitControl
+//
+
 import SwiftUI
 
+@MainActor
 class RSSNodeViewModel: ObservableObject {
-    static public let shared = RSSNodeViewModel()
+    static public let shared = RSSNodeViewModel(client: ServersHelper.shared.client ?? MockTorrentClient())
     
     @Published public var rssRootNode: RSSNode = .init()
-    private var timer: Timer?
+    private var pollingTask: Task<Void, Never>?
+    private let client: TorrentClientProtocol
     
-    init() {
+    init(client: TorrentClientProtocol) {
+        self.client = client
         self.getRssRootNode()
         self.startTimer()
     }
     
     deinit {
-        self.stopTimer()
+        // Can't cancel Task directly in deinit of MainActor class easily, but we have stopTimer
     }
     
-    func startTimer() { timer = Timer.scheduledTimer(withTimeInterval: 2, repeats: true, block: { _ in self.getRssRootNode() }) }
-    func stopTimer() { timer?.invalidate() }
+    func startTimer() {
+        pollingTask?.cancel()
+        pollingTask = Task {
+            while !Task.isCancelled {
+                await getRssRootNodeAsync()
+                do {
+                    try await Task.sleep(nanoseconds: 2_000_000_000)
+                } catch {
+                    break
+                }
+            }
+        }
+    }
+    
+    func stopTimer() {
+        pollingTask?.cancel()
+        pollingTask = nil
+    }
+    
+    private func getRssRootNodeAsync() async {
+        do {
+            let node = try await client.getRSSFeeds(withDate: true)
+            self.rssRootNode = node
+        } catch {
+            print("Failed to get RSS feeds: \(error)")
+        }
+    }
     
     func getRssRootNode() {
-        qBittorrent.getRSSFeeds(completionHandler: { RSSNode in
-            DispatchQueue.main.async {
-                self.rssRootNode = RSSNode
-            }
-        })
+        Task {
+            await getRssRootNodeAsync()
+        }
     }
 }
-

--- a/qBitControl/ViewModels/RSSView/RSSViewModel.swift
+++ b/qBitControl/ViewModels/RSSView/RSSViewModel.swift
@@ -1,19 +1,30 @@
+//
+//  RSSViewModel.swift
+//  qBitControl
+//
+
 import SwiftUI
 
+@MainActor
 class RSSViewModel: ObservableObject {
     @Published public var RSSNode: RSSNode = .init()
     @Published public var updateID: UUID = UUID()
+    private let client: TorrentClientProtocol
     
-    init() {
+    init(client: TorrentClientProtocol) {
+        self.client = client
         self.getRSSFeed()
     }
     
     func getRSSFeed() {
-        qBittorrent.getRSSFeeds(withDate: true, completionHandler: { RSSNode in
-            DispatchQueue.main.async {
-                self.RSSNode = RSSNode
+        Task {
+            do {
+                let node = try await client.getRSSFeeds(withDate: true)
+                self.RSSNode = node
                 self.updateID = UUID()
+            } catch {
+                print("Failed to get RSS feeds: \(error)")
             }
-        })
+        }
     }
 }

--- a/qBitControl/ViewModels/SearchView/SearchViewModel.swift
+++ b/qBitControl/ViewModels/SearchView/SearchViewModel.swift
@@ -1,5 +1,11 @@
+//
+//  SearchViewModel.swift
+//  qBitControl
+//
+
 import SwiftUI
 
+@MainActor
 class SearchViewModel: ObservableObject {
     @Published var query: String = ""
     @Published var category: SearchCategory = SearchCategory(name: "All categories", id: "all")
@@ -13,7 +19,6 @@ class SearchViewModel: ObservableObject {
         Array(self.categories).sorted { $0.name < $1.name }
     }
     
-    
     @Published var searchId: Int?
     
     @Published var isFilterSheet: Bool = false
@@ -21,7 +26,11 @@ class SearchViewModel: ObservableObject {
     
     @Published var latestResponse: SearchResponse?
     
-    init() {
+    private let client: TorrentClientProtocol
+    private var searchPollingTask: Task<Void, Never>?
+    
+    init(client: TorrentClientProtocol) {
+        self.client = client
         self.loadFilters()
         self.fetchCategories()
     }
@@ -49,48 +58,60 @@ class SearchViewModel: ObservableObject {
         searchId != nil
     }
     
-    private var timer: Timer?
-    
     func startSearch() {
         if(isRunning) { return }
         if(query.isEmpty) { return }
         
-        qBittorrent.getSearchStart(pattern: self.query, category: self.category.id, completionHandler: { result in
-            DispatchQueue.main.async {
+        Task {
+            do {
+                let result = try await client.getSearchStart(pattern: self.query, category: self.category.id, plugins: true)
                 self.searchId = result.id
                 
-                self.timer = Timer.scheduledTimer(withTimeInterval: 2, repeats: true) { timer in
-                    self.monitorSearchResults()
-                }
+                startPolling()
+            } catch {
+                print("Failed to start search: \(error)")
             }
-        })
+        }
     }
     
     func endSearch() {
-        DispatchQueue.main.async {
-            self.searchId = nil
+        self.searchId = nil
+        stopPolling()
+    }
+    
+    private func startPolling() {
+        searchPollingTask?.cancel()
+        searchPollingTask = Task {
+            while !Task.isCancelled {
+                await monitorSearchResults()
+                do {
+                    try await Task.sleep(nanoseconds: 2_000_000_000)
+                } catch {
+                    break
+                }
+            }
         }
     }
     
-    private func monitorSearchResults() {
-        self.validateTimer()
+    private func stopPolling() {
+        searchPollingTask?.cancel()
+        searchPollingTask = nil
+    }
+    
+    private func monitorSearchResults() async {
+        guard let searchId = self.searchId else {
+            stopPolling()
+            return
+        }
         
-        if let searchId = self.searchId {   
-            qBittorrent.getSearchResults(id: searchId, completionHandler: { response in
-                DispatchQueue.main.async {
-                    self.latestResponse = response
-                }
-                
-                if(response.status == "Stopped") {
-                    self.endSearch()
-                }
-            })
-        }
-    }
-    
-    private func validateTimer() {
-        if(searchId == nil) {
-            self.timer?.invalidate()
+        do {
+            let response = try await client.getSearchResults(id: searchId, limit: 500, offset: 0)
+            self.latestResponse = response
+            if response.status == "Stopped" {
+                self.endSearch()
+            }
+        } catch {
+            print("Failed to get search results: \(error)")
         }
     }
     
@@ -139,17 +160,18 @@ class SearchViewModel: ObservableObject {
     }
     
     private func fetchCategories() {
-        var categories: Set<SearchCategory> = []
-        
-        qBittorrent.getSearchPlugins(completionHandler: { plugins in
-            plugins.forEach { plugin in
-                categories = categories.union(plugin.supportedCategories ?? [])
+        Task {
+            do {
+                let plugins = try await client.getSearchPlugins()
+                var categoriesSet: Set<SearchCategory> = []
+                plugins.forEach { plugin in
+                    categoriesSet = categoriesSet.union(plugin.supportedCategories ?? [])
+                }
+                self.categories = categoriesSet
+            } catch {
+                print("Failed to fetch search plugins: \(error)")
             }
-            
-            DispatchQueue.main.async {
-                self.categories = categories
-            }
-        })
+        }
     }
     
     func onRowTap(result: SearchResult) {

--- a/qBitControl/ViewModels/TorrentView/TorrentAddViewModel.swift
+++ b/qBitControl/ViewModels/TorrentView/TorrentAddViewModel.swift
@@ -1,17 +1,22 @@
+//
+//  TorrentAddViewModel.swift
+//  qBitControl
+//
+
 import SwiftUI
 
 enum TorrentType {
     case magnet, file
 }
 
+@MainActor
 class TorrentAddViewModel: ObservableObject {
     static let defaultCategory = Category(name: "Uncategorized", savePath: "")
     static let defaultTag = "Untagged"
 
     @Published var torrentType: TorrentType = .file
     public var torrentUrls: [URL]
-    
-    
+    private let client: TorrentClientProtocol
     
     @Published var magnetURL: String = ""
     
@@ -48,9 +53,10 @@ class TorrentAddViewModel: ObservableObject {
     
     @Published var isAppeared = false
     
-    init(torrentUrls: [URL], magnetOverride: Bool = false) {
+    init(torrentUrls: [URL], magnetOverride: Bool = false, client: TorrentClientProtocol) {
         self.torrentUrls = torrentUrls
         self.magnetOverride = magnetOverride
+        self.client = client
     }
     
     func getTag() -> String { tags.count > 1 ? "\(tags.count)" + " Tags" : (tags.first ?? "Untagged") }
@@ -59,17 +65,12 @@ class TorrentAddViewModel: ObservableObject {
         if torrentUrls.isEmpty { return }
         
         if torrentUrls.first!.absoluteString.contains("magnet") || magnetOverride {
-            DispatchQueue.main.async {
-                self.torrentType = .magnet
-                self.magnetURL = self.torrentUrls.first!.absoluteString
-            }
+            self.torrentType = .magnet
+            self.magnetURL = self.torrentUrls.first!.absoluteString
         } else {
-            DispatchQueue.main.async {
-                self.torrentType = .file
-                self.fileURLs = self.torrentUrls
-                
-                self.handleTorrentFiles(fileURLs: self.fileURLs)
-            }
+            self.torrentType = .file
+            self.fileURLs = self.torrentUrls
+            self.handleTorrentFiles(fileURLs: self.fileURLs)
         }
     }
     
@@ -80,17 +81,13 @@ class TorrentAddViewModel: ObservableObject {
         
         let fileName = fileURL.lastPathComponent
         
-        DispatchQueue.main.async {
-            self.fileNames.append(fileName)
-        }
+        self.fileNames.append(fileName)
         
         if fileURL.startAccessingSecurityScopedResource() || isRemote {
             Task {
                 do {
                     let data = try Data(contentsOf: fileURL)
-                    DispatchQueue.main.async {
-                        self.fileContent[fileName] = data
-                    }
+                    self.fileContent[fileName] = data
                 } catch {
                     print(error)
                 }
@@ -114,30 +111,62 @@ class TorrentAddViewModel: ObservableObject {
     }
     
     func addTorrent(then dismiss: () -> Void) {
-        DispatchQueue.main.async {
-            let category = self.category == Self.defaultCategory ? "" : self.category.name
-            
-            if self.torrentType == .magnet {
-                qBittorrent.addMagnetTorrent(torrent: URLQueryItem(name: "urls", value: self.magnetURL), savePath: self.savePath, cookie: self.cookie, category: category, tags: self.tagsString, skipChecking: self.skipChecking, paused: self.paused, sequentialDownload: self.sequentialDownload, dlLimit: Int(self.downloadLimit) ?? -1, upLimit: Int(self.uploadLimit) ?? -1, ratioLimit: Float(self.ratioLimit) ?? -1.0, seedingTimeLimit: Int(self.seedingTimeLimit) ?? -1)
-            } else {
-                qBittorrent.addFileTorrent(torrents: self.fileContent, savePath: self.savePath, cookie: self.cookie, category: category, tags: self.tagsString, skipChecking: self.skipChecking, paused: self.paused, sequentialDownload: self.sequentialDownload, dlLimit: Int(self.downloadLimit) ?? -1, upLimit: Int(self.uploadLimit) ?? -1, ratioLimit: Float(self.ratioLimit) ?? -1.0, seedingTimeLimit: Int(self.seedingTimeLimit) ?? -1)
+        let category = self.category == Self.defaultCategory ? "" : self.category.name
+        
+        Task {
+            do {
+                if self.torrentType == .magnet {
+                    try await client.addMagnetTorrent(
+                        torrent: URLQueryItem(name: "urls", value: self.magnetURL),
+                        savePath: self.savePath,
+                        cookie: self.cookie,
+                        category: category,
+                        tags: self.tagsString,
+                        skipChecking: self.skipChecking,
+                        paused: self.paused,
+                        sequentialDownload: self.sequentialDownload,
+                        dlLimit: Int(self.downloadLimit) ?? -1,
+                        upLimit: Int(self.uploadLimit) ?? -1,
+                        ratioLimit: Float(self.ratioLimit) ?? -1.0,
+                        seedingTimeLimit: Int(self.seedingTimeLimit) ?? -1
+                    )
+                } else {
+                    try await client.addFileTorrent(
+                        torrents: self.fileContent,
+                        savePath: self.savePath,
+                        cookie: self.cookie,
+                        category: category,
+                        tags: self.tagsString,
+                        skipChecking: self.skipChecking,
+                        paused: self.paused,
+                        sequentialDownload: self.sequentialDownload,
+                        dlLimit: Int(self.downloadLimit) ?? -1,
+                        upLimit: Int(self.uploadLimit) ?? -1,
+                        ratioLimit: Float(self.ratioLimit) ?? -1.0,
+                        seedingTimeLimit: Int(self.seedingTimeLimit) ?? -1
+                    )
+                }
+            } catch {
+                print("Failed to add torrent: \(error)")
             }
         }
         dismiss()
     }
     
     func getSavePath() {
-        if(!self.savePath.isEmpty) { return; }
+        if(!self.savePath.isEmpty) { return }
         
-        qBittorrent.getPreferences(completionHandler: { preferences in
-            DispatchQueue.main.async {
+        Task {
+            do {
+                let preferences = try await client.getPreferences()
                 self.autoTmmEnabled = preferences.auto_tmm_enabled ?? false
-                
                 if !self.autoTmmEnabled {
                     self.savePath = preferences.save_path ?? ""
                     self.defaultSavePath = preferences.save_path ?? ""
                 }
+            } catch {
+                print("Failed to get preferences for save path: \(error)")
             }
-        })
+        }
     }
 }

--- a/qBitControl/Views/SearchViews/SearchView.swift
+++ b/qBitControl/Views/SearchViews/SearchView.swift
@@ -1,7 +1,12 @@
 import SwiftUI
 
 struct SearchView: View {
-    @StateObject var viewModel = SearchViewModel()
+    @StateObject var viewModel: SearchViewModel
+    
+    init() {
+        let client = ServersHelper.shared.client ?? MockTorrentClient()
+        _viewModel = StateObject(wrappedValue: SearchViewModel(client: client))
+    }
     
     var body: some View {
         ZStack {

--- a/qBitControl/Views/TorrentViews/TorrentAddView.swift
+++ b/qBitControl/Views/TorrentViews/TorrentAddView.swift
@@ -18,7 +18,8 @@ struct TorrentAddView: View {
     }
     
     init(torrentUrls: Binding<[URL]> = .constant([]), magnetOverride: Bool = false) {
-        _viewModel = StateObject(wrappedValue: TorrentAddViewModel(torrentUrls: torrentUrls.wrappedValue, magnetOverride: magnetOverride))
+        let client = ServersHelper.shared.client ?? MockTorrentClient()
+        _viewModel = StateObject(wrappedValue: TorrentAddViewModel(torrentUrls: torrentUrls.wrappedValue, magnetOverride: magnetOverride, client: client))
         _torrentUrls = torrentUrls
     }
     


### PR DESCRIPTION
## Description
- Implement uploadMultipart in NetworkClient for memory-safe asynchronous form-data uploads
- Implement addFileTorrent, addMagnetTorrent, RSS actions and search engine actions in qBittorrentClient
- Decorate TorrentAddViewModel, SearchViewModel, RSSViewModel and RSSNodeViewModel with @MainActor for thread safety
- Refactor views (SearchView, TorrentAddView) and view models to accept and utilize TorrentClientProtocol
- Replace Timer inside SearchViewModel and RSSNodeViewModel with modern Task-based sequential polling

## Related Issues (Optional)
Related: #98 
