### PR TITLE
feat(torrent): add localized error alerts for failed torrent additions

### DIFF
--- a/Localization/Localizations/Localizable.xcstrings
+++ b/Localization/Localizations/Localizable.xcstrings
@@ -3202,6 +3202,9 @@
         }
       }
     },
+    "Failed to Add Torrent" : {
+
+    },
     "Feeds" : {
       "localizations" : {
         "ja" : {
@@ -6064,7 +6067,7 @@
       }
     },
     "Request timed out. Please check your network connection." : {
-      "comment" : "RSS timeout error"
+      "comment" : "RSS timeout error\nTorrent add timeout error"
     },
     "results" : {
       "extractionState" : "manual",
@@ -6821,7 +6824,7 @@
       }
     },
     "Server returned error code %d." : {
-      "comment" : "RSS unknown error"
+      "comment" : "RSS unknown error\nTorrent add unknown error"
     },
     "Servers" : {
       "localizations" : {
@@ -7644,6 +7647,9 @@
     "The feed or folder already exists, or the specified path does not exist." : {
       "comment" : "RSS Conflict error"
     },
+    "The torrent file or magnet URL is invalid or unsupported." : {
+      "comment" : "Torrent invalid file/magnet error"
+    },
     "Time" : {
       "localizations" : {
         "ja" : {
@@ -7886,7 +7892,7 @@
       }
     },
     "Unauthorized. Please re-login to the server." : {
-      "comment" : "RSS unauthorized error"
+      "comment" : "RSS unauthorized error\nTorrent add unauthorized error"
     },
     "Uncategorized" : {
       "localizations" : {

--- a/qBitControl.xcodeproj/project.pbxproj
+++ b/qBitControl.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		909EE5A72CDD3B51002403DF /* TorrentAddError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 909EE5A82CDD3B51002403DF /* TorrentAddError.swift */; };
 		909EE5A52CDD3B51002403DF /* RSSError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 909EE5A62CDD3B51002403DF /* RSSError.swift */; };
 		909EE5A32CDD3B51002403DF /* RSSFeedViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 909EE5A42CDD3B4E002403DF /* RSSFeedViewModel.swift */; };
 		90EF6A5D29093142001E9F75 /* SmoothProgressBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90EF6A5D29093142001E9F74 /* SmoothProgressBar.swift */; };
@@ -129,6 +130,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		909EE5A82CDD3B51002403DF /* TorrentAddError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TorrentAddError.swift; sourceTree = "<group>"; };
 		909EE5A62CDD3B51002403DF /* RSSError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RSSError.swift; sourceTree = "<group>"; };
 		909EE5A42CDD3B4E002403DF /* RSSFeedViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RSSFeedViewModel.swift; sourceTree = "<group>"; };
 		90EF6A5D29093142001E9F74 /* SmoothProgressBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmoothProgressBar.swift; sourceTree = "<group>"; };
@@ -334,6 +336,7 @@
 				90AE89332CDB7316000E0276 /* RSSNode.swift */,
 				90726B162CDA22160032993E /* RSSFeed.swift */,
 				909EE5A62CDD3B51002403DF /* RSSError.swift */,
+				909EE5A82CDD3B51002403DF /* TorrentAddError.swift */,
 				90726B172CDA22160032993E /* Server.swift */,
 				90726B182CDA22160032993E /* ServerAction.swift */,
 				90726B192CDA22160032993E /* ServerState.swift */,
@@ -779,6 +782,7 @@
 				90726B282CDA22160032993E /* qBitPreferences.swift in Sources */,
 				90726B292CDA22160032993E /* RSSFeed.swift in Sources */,
 				909EE5A52CDD3B51002403DF /* RSSError.swift in Sources */,
+				909EE5A72CDD3B51002403DF /* TorrentAddError.swift in Sources */,
 				90726B2A2CDA22160032993E /* Server.swift in Sources */,
 				90726B2B2CDA22160032993E /* ServerAction.swift in Sources */,
 				90726B2C2CDA22160032993E /* ServerState.swift in Sources */,

--- a/qBitControl/Models/TorrentAddError.swift
+++ b/qBitControl/Models/TorrentAddError.swift
@@ -1,0 +1,35 @@
+//
+//  TorrentAddError.swift
+//  qBitControl
+//
+
+import Foundation
+
+enum TorrentAddError: LocalizedError, Identifiable {
+    case invalidFileOrMagnet
+    case unauthorized
+    case timeout
+    case unknown(Int)
+    
+    var id: String {
+        switch self {
+        case .invalidFileOrMagnet: return "invalidFileOrMagnet"
+        case .unauthorized: return "unauthorized"
+        case .timeout: return "timeout"
+        case .unknown(let code): return "unknown_\(code)"
+        }
+    }
+    
+    var errorDescription: String? {
+        switch self {
+        case .invalidFileOrMagnet:
+            return NSLocalizedString("The torrent file or magnet URL is invalid or unsupported.", comment: "Torrent invalid file/magnet error")
+        case .unauthorized:
+            return NSLocalizedString("Unauthorized. Please re-login to the server.", comment: "Torrent add unauthorized error")
+        case .timeout:
+            return NSLocalizedString("Request timed out. Please check your network connection.", comment: "Torrent add timeout error")
+        case .unknown(let statusCode):
+            return String(format: NSLocalizedString("Server returned error code %d.", comment: "Torrent add unknown error"), statusCode)
+        }
+    }
+}

--- a/qBitControl/ViewModels/TorrentView/TorrentAddViewModel.swift
+++ b/qBitControl/ViewModels/TorrentView/TorrentAddViewModel.swift
@@ -52,6 +52,7 @@ class TorrentAddViewModel: ObservableObject {
     @Published var seedingTimeLimit = ""
     
     @Published var isAppeared = false
+    @Published var activeError: TorrentAddError? = nil
     
     init(torrentUrls: [URL], magnetOverride: Bool = false, client: TorrentClientProtocol) {
         self.torrentUrls = torrentUrls
@@ -121,7 +122,7 @@ class TorrentAddViewModel: ObservableObject {
         }
     }
     
-    func addTorrent(then dismiss: () -> Void) {
+    func addTorrent(then dismiss: @escaping () -> Void) {
         let category = self.category == Self.defaultCategory ? "" : self.category.name
         
         Task {
@@ -157,11 +158,12 @@ class TorrentAddViewModel: ObservableObject {
                         seedingTimeLimit: Int(self.seedingTimeLimit) ?? -1
                     )
                 }
+                dismiss()
             } catch {
                 print("Failed to add torrent: \(error)")
+                self.activeError = self.mapError(error)
             }
         }
-        dismiss()
     }
     
     func getSavePath() {
@@ -179,5 +181,26 @@ class TorrentAddViewModel: ObservableObject {
                 print("Failed to get preferences for save path: \(error)")
             }
         }
+    }
+    
+    private func mapError(_ error: Error) -> TorrentAddError {
+        if let networkError = error as? NetworkError {
+            switch networkError {
+            case .invalidURL:
+                return .invalidFileOrMagnet
+            case .unauthorized:
+                return .unauthorized
+            case .timeout:
+                return .timeout
+            case .invalidResponse:
+                return .unknown(0)
+            case .httpError(let statusCode):
+                if statusCode == 415 || statusCode == 400 {
+                    return .invalidFileOrMagnet
+                }
+                return .unknown(statusCode)
+            }
+        }
+        return .unknown(0)
     }
 }

--- a/qBitControl/Views/TorrentViews/TorrentAddView.swift
+++ b/qBitControl/Views/TorrentViews/TorrentAddView.swift
@@ -60,6 +60,13 @@ struct TorrentAddView: View {
                     Button { viewModel.addTorrent(then: dismiss) } label: { Text("Add") }
                 }
             }
+            .alert(item: $viewModel.activeError) { error in
+                Alert(
+                    title: Text("Failed to Add Torrent"),
+                    message: Text(error.localizedDescription),
+                    dismissButton: .default(Text("OK"))
+                )
+            }
         }
     }
     


### PR DESCRIPTION
## Summary
This Pull Request introduces user-facing error reporting for failed torrent additions. It updates the layout flow to prevent sheet dismissal on network failure, maps HTTP status codes to localized domain errors, and presents alert modal feedback.

## Key Changes
* **Models**: Introduce `TorrentAddError` enum mapping API response codes (such as HTTP 400 and 415) and connection errors to localized string representations.
* **ViewModels**: Refactor `TorrentAddViewModel` to publish an `activeError` property, change the sheet dismiss handler to `@escaping`, and handle failures asynchronously.
* **Views**: Bind `.alert(item:)` in `TorrentAddView` to show user alerts and clear error state on dismissal.

## Technical Notes
* The sheet dismissal callback is now only executed upon a successful HTTP response, preventing premature sheet dismissal when validation errors occur.