### PR TITLE
feat(auth): implement background silent reauthentication on unauthorized telemetry errors

### DIFF
--- a/qBitControl/Classes/ServersHelper.swift
+++ b/qBitControl/Classes/ServersHelper.swift
@@ -200,6 +200,32 @@ class ServersHelper: ObservableObject {
         }
     }
     
+    func reauthenticate() async throws {
+        guard let activeId = activeServerId, let server = getServer(id: activeId) else {
+            throw NetworkError.unauthorized
+        }
+        
+        let networkClient = NetworkClient(baseURL: server.url, basicAuth: server.basicAuth)
+        let newClient = qBittorrentClient(networkClient: networkClient)
+        
+        do {
+            try await newClient.login(username: server.username, password: server.password)
+            self.client = newClient
+            self.isLoggedIn = true
+            AppLogger.log(.info, SystemEventPayload(category: .auth, eventName: "silent_reauth_success", message: "Successfully silently reauthenticated server: \(server.name)"))
+        } catch {
+            AppLogger.log(.error, GeneralErrorPayload(category: .auth, eventName: "silent_reauth_failed", errorDescription: error.localizedDescription))
+            
+            if let networkError = error as? NetworkError, networkError == .unauthorized {
+                // Permanent auth failure (e.g. password changed) -> Log out and show login screen
+                self.isLoggedIn = false
+                self.client = nil
+                self.clearCache()
+            }
+            throw error
+        }
+    }
+    
     func fetchMetadata() async {
         guard let client = client else { return }
         do {

--- a/qBitControl/Classes/ServersHelper.swift
+++ b/qBitControl/Classes/ServersHelper.swift
@@ -24,6 +24,9 @@ class ServersHelper: ObservableObject {
     @Published public var categories: [String: Category] = [:]
     @Published public var tags: [String] = []
     
+    // For unit testing tracking
+    public var reauthAttemptCount = 0
+    
     init() {
         getServerList()
         getActiveServer()
@@ -201,6 +204,7 @@ class ServersHelper: ObservableObject {
     }
     
     func reauthenticate() async throws {
+        reauthAttemptCount += 1
         guard let activeId = activeServerId, let server = getServer(id: activeId) else {
             throw NetworkError.unauthorized
         }

--- a/qBitControl/Classes/qBitDataClass.swift
+++ b/qBitControl/Classes/qBitDataClass.swift
@@ -107,6 +107,15 @@ class qBitData: ObservableObject {
             self.connectionStatus = .connected
         } catch {
             AppLogger.log(.error, GeneralErrorPayload(category: .system, eventName: "telemetry_fetch_failed", errorDescription: error.localizedDescription))
+            
+            if let networkError = error as? NetworkError, networkError == .unauthorized {
+                do {
+                    try await ServersHelper.shared.reauthenticate()
+                } catch {
+                    // Silent reauth failed. Permanent failure is handled in reauthenticate()
+                }
+            }
+            
             self.connectionStatus = .offline
         }
     }

--- a/qBitControlTests/qBitDataTests.swift
+++ b/qBitControlTests/qBitDataTests.swift
@@ -110,4 +110,33 @@ final class qBitDataTests: XCTestCase {
         await qBitData.shared.getMainData()
         XCTAssertEqual(mockClient.fetchCount, 2)
     }
+    
+    private class MockUnauthorizedClient: MockTorrentClient {
+        override func getMainData(rid: Int = 0) async throws -> MainData {
+            throw NetworkError.unauthorized
+        }
+    }
+    
+    @MainActor
+    func test_getMainData_onUnauthorizedError_triggersSilentReauthentication() async {
+        let mockClient = MockUnauthorizedClient()
+        ServersHelper.shared.client = mockClient
+        ServersHelper.shared.isLoggedIn = true
+        
+        let testServer = Server(
+            id: "test-auth-id",
+            name: "Test Server",
+            url: "http://127.0.0.1",
+            username: "admin",
+            password: "password",
+            basicAuth: nil
+        )
+        ServersHelper.shared.servers = [testServer]
+        ServersHelper.shared.activeServerId = testServer.id
+        ServersHelper.shared.reauthAttemptCount = 0
+        
+        await qBitData.shared.getMainData()
+        
+        XCTAssertEqual(ServersHelper.shared.reauthAttemptCount, 1)
+    }
 }


### PR DESCRIPTION
## Summary
Introduces background silent reauthentication when the telemetry poll encounters a 401 Unauthorized or 403 Forbidden error. This recovers active user sessions seamlessly when cookies expire without prompting a login screen, while gracefully logging the user out if their actual credentials become invalid.

## Key Changes
* **Connection Lifecycle**: Added `reauthenticate()` to `ServersHelper` to perform background logins using active credentials and update the shared client instances.
* **Telemetry Integration**: Modified `getMainData()` in `qBitData` to catch `NetworkError.unauthorized` and trigger a single reauthentication attempt.
* **Session Protection**: Configured the reauthentication block to automatically clear cached data, release client instances, and return the user to the login screen only if the re-login attempt fails due to invalid credentials (preventing account lockouts).
* **Testing**: Added `test_getMainData_onUnauthorizedError_triggersSilentReauthentication` to verify the reauth trigger path under mock client conditions.
