### PR TITLE
fix(stats): decouple chart timeline ticks from network request latency

### DIFF
--- a/qBitControl/Classes/qBitDataClass.swift
+++ b/qBitControl/Classes/qBitDataClass.swift
@@ -21,6 +21,8 @@ class qBitData: ObservableObject {
     private var fetchInterval: UInt64 = 2_000_000_000 // 2 seconds
     
     private var isFetching = false
+    private var latestDlSpeed = 0
+    private var latestUpSpeed = 0
     
     init() {
         let date = Date()
@@ -37,7 +39,14 @@ class qBitData: ObservableObject {
         pollingTask?.cancel()
         pollingTask = Task {
             while !Task.isCancelled {
-                await self.getMainData()
+                // Trigger the network call in the background on the MainActor
+                Task { @MainActor in
+                    await self.getMainData()
+                }
+                
+                // Immediately append the latest known speed to the timeline history
+                self.appendTransferInfo()
+                
                 do {
                     try await Task.sleep(nanoseconds: fetchInterval)
                 } catch {
@@ -54,6 +63,8 @@ class qBitData: ObservableObject {
     
     func resetTransferHistory() {
         let date = Date()
+        self.latestDlSpeed = 0
+        self.latestUpSpeed = 0
         self.dlTransferData.removeAll()
         self.upTransferData.removeAll()
         for n in stride(from: -30, to: 0, by: 2) {
@@ -92,21 +103,16 @@ class qBitData: ObservableObject {
                     self.serverState = ServerState(from: partialServerState)
                 }
                 
-                let newDlTransferInfo = TransferInfo(fetchDate: Date(), info_speed: partialServerState.dl_info_speed ?? 0)
-                self.dlTransferData.append(newDlTransferInfo)
-                
-                // Limit the history to the last 20 entries
-                if self.dlTransferData.count > 20 { self.dlTransferData.removeFirst(self.dlTransferData.count - 20) }
-                
-                let newUpTransferInfo = TransferInfo(fetchDate: Date(), info_speed: partialServerState.up_info_speed ?? 0)
-                self.upTransferData.append(newUpTransferInfo)
-                
-                // Limit the history to the last 20 entries
-                if self.upTransferData.count > 20 { self.upTransferData.removeFirst(self.upTransferData.count - 20) }
+                self.latestDlSpeed = partialServerState.dl_info_speed ?? 0
+                self.latestUpSpeed = partialServerState.up_info_speed ?? 0
             }
             self.connectionStatus = .connected
         } catch {
             AppLogger.log(.error, GeneralErrorPayload(category: .system, eventName: "telemetry_fetch_failed", errorDescription: error.localizedDescription))
+            
+            self.latestDlSpeed = 0
+            self.latestUpSpeed = 0
+            self.rid = 0 // Reset rid on network failure to force full update on recovery
             
             if let networkError = error as? NetworkError, networkError == .unauthorized {
                 do {
@@ -118,5 +124,15 @@ class qBitData: ObservableObject {
             
             self.connectionStatus = .offline
         }
+    }
+    
+    private func appendTransferInfo() {
+        let dlPoint = TransferInfo(fetchDate: Date(), info_speed: latestDlSpeed)
+        self.dlTransferData.append(dlPoint)
+        if self.dlTransferData.count > 20 { self.dlTransferData.removeFirst(self.dlTransferData.count - 20) }
+        
+        let upPoint = TransferInfo(fetchDate: Date(), info_speed: latestUpSpeed)
+        self.upTransferData.append(upPoint)
+        if self.upTransferData.count > 20 { self.upTransferData.removeFirst(self.upTransferData.count - 20) }
     }
 }

--- a/qBitControl/Views/TorrentViews/StatsView.swift
+++ b/qBitControl/Views/TorrentViews/StatsView.swift
@@ -41,6 +41,9 @@ struct StatsView: View {
     }
     
     private func getDelayedSpeed(from transferData: [TransferInfo], delay: TimeInterval = 3.0) -> Int {
+        if let lastPoint = transferData.last, Date().timeIntervalSince(lastPoint.fetchDate) > 5.0 {
+            return 0
+        }
         let targetDate = Date().addingTimeInterval(-delay)
         return transferData.min(by: {
             abs($0.fetchDate.timeIntervalSince(targetDate)) < abs($1.fetchDate.timeIntervalSince(targetDate))


### PR DESCRIPTION
## Summary
Chart timeline data points were previously appended only on successful network responses, causing visual stutter and desync when request latency varied. This PR records transfer speed at a fixed 2-second cadence using cached latest values, independent of network timing.

## Key Changes
* **qBitData**: Cache latest `dl_info_speed` / `up_info_speed` from network responses and append `TransferInfo` points on the polling timer rather than inside `getMainData()`
* **qBitData**: Reset `rid` to `0` on network failure to force a full data refresh on recovery
* **StatsView**: Guard `getDelayedSpeed` to return 0 when the last data point is older than 5 seconds (offline/stale)

## Technical Notes
* `getMainData()` is now fire-and-forget within the polling loop; the `isFetching` guard prevents overlapping network calls
* When RTT exceeds 2s, subsequent polls bail on `isFetching` and continue recording the last known speed — intentional trade-off to maintain consistent tick spacing