### PR TITLE
fix(telemetry): recover stale URLSession on persistent fetch failures

### DIFF
--- a/qBitControl/Classes/ServersHelper.swift
+++ b/qBitControl/Classes/ServersHelper.swift
@@ -26,6 +26,7 @@ class ServersHelper: ObservableObject {
     
     // For unit testing tracking
     public var reauthAttemptCount = 0
+    public var refreshClientCallCount = 0
     
     init() {
         getServerList()
@@ -133,12 +134,19 @@ class ServersHelper: ObservableObject {
     }
     
     func connect(server: Server, result: ((Bool) -> Void)?) {
+        qBitData.shared.stopPolling()
+        
         if server.id != activeServerId {
             self.clearCache()
         }
         connectingServerId = server.id
         
         Task {
+            defer {
+                self.connectingServerId = nil
+                qBitData.shared.startPolling()
+            }
+            
             let networkClient = NetworkClient(baseURL: server.url, basicAuth: server.basicAuth)
             let newClient = qBittorrentClient(networkClient: networkClient)
             do {
@@ -155,17 +163,23 @@ class ServersHelper: ObservableObject {
             } catch {
                 result?(false)
             }
-            self.connectingServerId = nil
         }
     }
     
     func connect(server: Server) {
+        qBitData.shared.stopPolling()
+        
         if server.id != activeServerId {
             self.clearCache()
         }
         connectingServerId = server.id
         
         Task {
+            defer {
+                self.connectingServerId = nil
+                qBitData.shared.startPolling()
+            }
+            
             let networkClient = NetworkClient(baseURL: server.url, basicAuth: server.basicAuth)
             let newClient = qBittorrentClient(networkClient: networkClient)
             do {
@@ -189,7 +203,6 @@ class ServersHelper: ObservableObject {
                     return client
                 }
                 
-                // Mutating and invoking actor-isolated methods safely on the MainActor
                 self.client = loggedInClient
                 self.setActiveServer(id: server.id)
                 await self.fetchMetadata()
@@ -199,10 +212,26 @@ class ServersHelper: ObservableObject {
             } catch {
                 AppLogger.log(.error, GeneralErrorPayload(category: .auth, eventName: "auto_connect_failed", errorDescription: error.localizedDescription))
             }
-            self.connectingServerId = nil
         }
     }
     
+    func refreshClient() async {
+        refreshClientCallCount += 1
+        guard let activeId = activeServerId, let server = getServer(id: activeId) else { return }
+
+        let networkClient = NetworkClient(baseURL: server.url, basicAuth: server.basicAuth)
+        let newClient = qBittorrentClient(networkClient: networkClient)
+
+        do {
+            try await newClient.login(username: server.username, password: server.password)
+            self.client = newClient
+            self.isLoggedIn = true
+            AppLogger.log(.info, SystemEventPayload(category: .system, eventName: "client_refresh_success", message: "Successfully refreshed client for server: \(server.name)"))
+        } catch {
+            AppLogger.log(.error, GeneralErrorPayload(category: .system, eventName: "client_refresh_failed", errorDescription: error.localizedDescription))
+        }
+    }
+
     func reauthenticate() async throws {
         reauthAttemptCount += 1
         guard let activeId = activeServerId, let server = getServer(id: activeId) else {

--- a/qBitControl/Classes/qBitDataClass.swift
+++ b/qBitControl/Classes/qBitDataClass.swift
@@ -120,6 +120,9 @@ class qBitData: ObservableObject {
                 } catch {
                     // Silent reauth failed. Permanent failure is handled in reauthenticate()
                 }
+            } else if self.connectionStatus == .offline {
+                // Already offline — attempt recovery by creating a fresh URLSession client
+                await ServersHelper.shared.refreshClient()
             }
             
             self.connectionStatus = .offline

--- a/qBitControlTests/qBitDataTests.swift
+++ b/qBitControlTests/qBitDataTests.swift
@@ -35,6 +35,7 @@ final class qBitDataTests: XCTestCase {
         qBitData.shared.stopPolling()
         ServersHelper.shared.client = nil
         ServersHelper.shared.isLoggedIn = false
+        ServersHelper.shared.refreshClientCallCount = 0
     }
     
     @MainActor
@@ -138,5 +139,56 @@ final class qBitDataTests: XCTestCase {
         await qBitData.shared.getMainData()
         
         XCTAssertEqual(ServersHelper.shared.reauthAttemptCount, 1)
+    }
+    
+    @MainActor
+    func test_getMainData_onFirstNonAuthFailure_doesNotTriggerRefreshClient() async {
+        let mockClient = MockDelayClient()
+        mockClient.shouldThrow = true
+        ServersHelper.shared.client = mockClient
+        ServersHelper.shared.isLoggedIn = true
+        qBitData.shared.connectionStatus = .connected
+        
+        let testServer = Server(
+            id: "test-refresh-id",
+            name: "Test Server",
+            url: "http://127.0.0.1",
+            username: "admin",
+            password: "password",
+            basicAuth: nil
+        )
+        ServersHelper.shared.servers = [testServer]
+        ServersHelper.shared.activeServerId = testServer.id
+        ServersHelper.shared.refreshClientCallCount = 0
+        
+        await qBitData.shared.getMainData()
+        
+        XCTAssertEqual(ServersHelper.shared.refreshClientCallCount, 0)
+        XCTAssertEqual(qBitData.shared.connectionStatus, .offline)
+    }
+    
+    @MainActor
+    func test_getMainData_onSecondNonAuthFailure_triggersRefreshClient() async {
+        let mockClient = MockDelayClient()
+        mockClient.shouldThrow = true
+        ServersHelper.shared.client = mockClient
+        ServersHelper.shared.isLoggedIn = true
+        qBitData.shared.connectionStatus = .offline
+        
+        let testServer = Server(
+            id: "test-refresh-id",
+            name: "Test Server",
+            url: "http://127.0.0.1",
+            username: "admin",
+            password: "password",
+            basicAuth: nil
+        )
+        ServersHelper.shared.servers = [testServer]
+        ServersHelper.shared.activeServerId = testServer.id
+        ServersHelper.shared.refreshClientCallCount = 0
+        
+        await qBitData.shared.getMainData()
+        
+        XCTAssertEqual(ServersHelper.shared.refreshClientCallCount, 1)
     }
 }


### PR DESCRIPTION
## Summary
Fixes the "internet connection appears to be offline" error that occurs after device sleep by recovering stale URLSession connections and preventing polling races during reconnect.

## Key Changes
* **Telemetry**: Added `refreshClient()` recovery path in `getMainData()` that creates a fresh `NetworkClient` on consecutive non-401 fetch failures, replacing dead URLSession connections accumulated during device sleep.
* **Connection**: Both `connect()` overloads now stop the telemetry polling loop before reconnecting and restart it afterward via `defer`, preventing the polling loop from racing with the reconnect flow on a stale client.
* **Tests**: Added two unit tests verifying that `refreshClient()` is skipped on the first failure (isolated blip) and triggered on consecutive failures (persistent offline state).

## Technical Notes
* `refreshClient()` differs from `reauthenticate()` — it targets network-layer client recovery (fresh `URLSession`) rather than auth-layer session refresh. Both are serialized by the existing `isFetching` guard to prevent concurrent recovery attempts.
* The recovery triggers on the second consecutive failure (when `connectionStatus` is already `.offline`), not the first, to avoid unnecessary reconnections on isolated transient errors.