### PR TITLE
fix(rss): prevent stale TorrentAddViewModel reuse across sheet presentations

### DIFF
--- a/qBitControl/Models/RSSFeed.swift
+++ b/qBitControl/Models/RSSFeed.swift
@@ -4,7 +4,7 @@
 import Foundation
 
 struct RSSFeed: Decodable, Identifiable {
-    var id: UUID { UUID() }
+    var id: String { url ?? uid ?? UUID().uuidString }
     let url: String?
     let uid: String?
     let isLoading: Bool?
@@ -13,7 +13,7 @@ struct RSSFeed: Decodable, Identifiable {
     let articles: [Article]
     
     struct Article: Decodable, Identifiable {
-        var id: UUID { UUID() }
+        var id: String { torrentURL ?? link ?? UUID().uuidString }
         let category: String?
         let title: String?
         let date: String?

--- a/qBitControl/Views/RSSViews/RSSFeedView.swift
+++ b/qBitControl/Views/RSSViews/RSSFeedView.swift
@@ -36,6 +36,7 @@ struct RSSFeedView: View {
         .sheet(item: $viewModel.selectedArticle) { _ in
             if let url = viewModel.selectedTorrentURL {
                 TorrentAddView(torrentUrls: .constant([url]))
+                    .id(url)
             }
         }
         .searchable(text: $viewModel.searchQuery)

--- a/qBitControl/Views/SearchViews/SearchView.swift
+++ b/qBitControl/Views/SearchViews/SearchView.swift
@@ -65,6 +65,11 @@ struct SearchView: View {
             }
         }.sheet(isPresented: $viewModel.isFilterSheet) {
             SearchFiltersView(viewModel: viewModel)
-        }.sheet(isPresented: $viewModel.isTorrentAddSheet) { if let url = URL(string: self.viewModel.tappedResult?.fileUrl ?? "") { TorrentAddView(torrentUrls: .constant([url]), magnetOverride: true) } }
+        }.sheet(isPresented: $viewModel.isTorrentAddSheet) {
+            if let url = URL(string: self.viewModel.tappedResult?.fileUrl ?? "") {
+                TorrentAddView(torrentUrls: .constant([url]), magnetOverride: true)
+                    .id(url)
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
Fixes a bug where adding a torrent from RSS incorrectly shows the "already in your download list" alert for a torrent that is not actually present. Caused by `@StateObject` ViewModel reuse across .sheet(item:) presentations, combined with unstable Article.id identities.

## Key Changes
* **RSS Feed**: Changed Article.id and RSSFeed.id from var id: UUID { UUID() } to stable derived strings using torrentURL, link, or url — giving SwiftUI reliable identities for ForEach diffing and sheet(item:) tracking.
* **RSS Feed View**: Added .id(url) on TorrentAddView inside the sheet content closure to force fresh view and `@StateObject `creation per unique torrent URL.
* **Search View**: Same .id(url) fix applied for consistency; also reformatted inline closure for readability.

## Technical Notes
* The root cause was `@StateObject` retaining the ViewModel from the first sheet presentation. The subsequent presentation reused the stale VM with old torrentUrls and fileContent, skipping checkTorrentType() because isAppeared was already true.
* .id(url) forces SwiftUI to treat each distinct URL as a new view identity, triggering destruction of the previous `@StateObject` and creation of a fresh one.