### PR TITLE
fix(filter): extract TorrentFilterStrategy, fix active filter, align with qBittorrent 5.2.0

### DIFF
--- a/.github/workflows/automated-ios-build.yml
+++ b/.github/workflows/automated-ios-build.yml
@@ -44,7 +44,6 @@ jobs:
       with:
         repo_token: "${{ secrets.GITHUB_TOKEN }}"
         prerelease: true
-        automatic_release_tag: "CI"
         title: "qBitControl ${{ env.VERSION }} (${{ env.BUILD_NUMBER }})"
         files: |
           qBitControl.ipa

--- a/Localization/Localizations/Localizable.xcstrings
+++ b/Localization/Localizations/Localizable.xcstrings
@@ -525,6 +525,7 @@
       }
     },
     "Active Downloading" : {
+      "extractionState" : "stale",
       "localizations" : {
         "ja" : {
           "stringUnit" : {
@@ -565,6 +566,7 @@
       }
     },
     "Active Seeding" : {
+      "extractionState" : "stale",
       "localizations" : {
         "ja" : {
           "stringUnit" : {
@@ -1975,6 +1977,9 @@
           }
         }
       }
+    },
+    "Checking" : {
+
     },
     "Clear Completed" : {
       "localizations" : {
@@ -5559,6 +5564,9 @@
         }
       }
     },
+    "Moving" : {
+
+    },
     "Music" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -7635,6 +7643,7 @@
       }
     },
     "Resumed" : {
+      "extractionState" : "stale",
       "localizations" : {
         "ja" : {
           "stringUnit" : {
@@ -7773,6 +7782,9 @@
           }
         }
       }
+    },
+    "Running" : {
+
     },
     "Save" : {
       "localizations" : {
@@ -8800,6 +8812,12 @@
         }
       }
     },
+    "Stalled Downloading" : {
+
+    },
+    "Stalled Uploading" : {
+
+    },
     "Start" : {
       "localizations" : {
         "ja" : {
@@ -9095,6 +9113,9 @@
           }
         }
       }
+    },
+    "Stopped" : {
+
     },
     "Super Seeding" : {
       "comment" : "Name of the share limit action that enables super seeding.",

--- a/Localization/Localizations/Localizable.xcstrings
+++ b/Localization/Localizations/Localizable.xcstrings
@@ -4429,6 +4429,7 @@
       }
     },
     "Help with translation" : {
+      "extractionState" : "stale",
       "localizations" : {
         "ja" : {
           "stringUnit" : {

--- a/qBitControl.xcodeproj/project.pbxproj
+++ b/qBitControl.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		901AC21C3003A6F800DFD12A /* TorrentLimitsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 901AC21B3003A6F800DFD12A /* TorrentLimitsView.swift */; };
 		901AC21E3003AC4900DFD12A /* SeedingLimitOption.swift in Sources */ = {isa = PBXBuildFile; fileRef = 901AC21D3003AC4900DFD12A /* SeedingLimitOption.swift */; };
 		901AC220300426A700DFD12A /* ShareLimitAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 901AC21F300426A700DFD12A /* ShareLimitAction.swift */; };
+		901AC226300695DC00DFD12A /* TorrentFilterStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 901AC225300695DC00DFD12A /* TorrentFilterStrategy.swift */; };
 		90200BA52B44BA6F00D3BA55 /* logo1.png in Resources */ = {isa = PBXBuildFile; fileRef = 90200BA42B44BA6E00D3BA55 /* logo1.png */; };
 		90200BA62B44BA6F00D3BA55 /* logo1.png in Resources */ = {isa = PBXBuildFile; fileRef = 90200BA42B44BA6E00D3BA55 /* logo1.png */; };
 		90200BA72B44BA6F00D3BA55 /* logo1.png in Resources */ = {isa = PBXBuildFile; fileRef = 90200BA42B44BA6E00D3BA55 /* logo1.png */; };
@@ -157,6 +158,7 @@
 		901AC21B3003A6F800DFD12A /* TorrentLimitsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TorrentLimitsView.swift; sourceTree = "<group>"; };
 		901AC21D3003AC4900DFD12A /* SeedingLimitOption.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeedingLimitOption.swift; sourceTree = "<group>"; };
 		901AC21F300426A700DFD12A /* ShareLimitAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareLimitAction.swift; sourceTree = "<group>"; };
+		901AC225300695DC00DFD12A /* TorrentFilterStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TorrentFilterStrategy.swift; sourceTree = "<group>"; };
 		90200BA42B44BA6E00D3BA55 /* logo1.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = logo1.png; path = qBitControl/Assets.xcassets/AppIcon.appiconset/logo1.png; sourceTree = "<group>"; };
 		90200BA82B44BC2600D3BA55 /* qBitControlTests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "qBitControlTests-Bridging-Header.h"; sourceTree = "<group>"; };
 		90200BA92B44BC2600D3BA55 /* qBitControlUITests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "qBitControlUITests-Bridging-Header.h"; sourceTree = "<group>"; };
@@ -392,6 +394,7 @@
 				90726B1D2CDA22160032993E /* TransferInfo.swift */,
 				901AC21D3003AC4900DFD12A /* SeedingLimitOption.swift */,
 				901AC21F300426A700DFD12A /* ShareLimitAction.swift */,
+				901AC225300695DC00DFD12A /* TorrentFilterStrategy.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -786,6 +789,7 @@
 				90EF6A5D29093142001E9F71 /* TorrentSortOption.swift in Sources */,
 				90EF6A5D29093142001E9F73 /* TorrentFilterOption.swift in Sources */,
 				90EF6A4D29093142001E9F61 /* PartialTorrent.swift in Sources */,
+				901AC226300695DC00DFD12A /* TorrentFilterStrategy.swift in Sources */,
 				90EF6A4D29093142001E9F63 /* TorrentCacheManager.swift in Sources */,
 				90EF6A4D29093142001E9F02 /* TorrentClientProtocol.swift in Sources */,
 				90EF6A4D29093142001E9F04 /* qBittorrentClient.swift in Sources */,

--- a/qBitControl/Models/Torrent.swift
+++ b/qBitControl/Models/Torrent.swift
@@ -157,4 +157,26 @@ extension Torrent {
         self.init(hash: hash)
         self.update(from: partial)
     }
+    
+    mutating func applyPause() {
+        state = progress < 1.0 ? "pausedDL" : "pausedUP"
+        dlspeed = 0
+        upspeed = 0
+    }
+    
+    mutating func applyResume() {
+        state = progress < 1.0 ? "downloading" : "uploading"
+    }
+    
+    mutating func applyForceStart() {
+        state = progress < 1.0 ? "forcedDL" : "forcedUP"
+    }
+    
+    mutating func applyForceStartStop() {
+        state = progress < 1.0 ? "downloading" : "uploading"
+    }
+    
+    mutating func applyRecheck() {
+        state = progress < 1.0 ? "checkingDL" : "checkingUP"
+    }
 }

--- a/qBitControl/Models/TorrentFilterOption.swift
+++ b/qBitControl/Models/TorrentFilterOption.swift
@@ -2,16 +2,17 @@ import Foundation
 
 enum TorrentFilterOption: String, CaseIterable, Codable {
     case all
-    case resumed
+    case running
     case stalledUploading = "stalled_uploading"
     case stalledDownloading = "stalled_downloading"
     case downloading
     case seeding
     case completed
-    case paused
+    case stopped
     case active
     case inactive
     case stalled
     case errored
     case checking
+    case moving
 }

--- a/qBitControl/Models/TorrentFilterStrategy.swift
+++ b/qBitControl/Models/TorrentFilterStrategy.swift
@@ -16,12 +16,18 @@ struct QBitTorrentFilterStrategy: TorrentFilterStrategy {
             return torrent.state == "downloading"
                 || torrent.state == "stalledDL"
                 || torrent.state == "checkingDL"
+                || torrent.state == "queuedDL"
                 || torrent.state == "metaDL"
                 || torrent.state == "forcedDL"
                 || torrent.state == "allocating"
-        case .completed, .seeding:
-            return torrent.state == "seeding"
-                || torrent.state == "uploading"
+        case .seeding:
+            return torrent.state == "uploading"
+                || torrent.state == "stalledUP"
+                || torrent.state == "checkingUP"
+                || torrent.state == "forcedUP"
+                || torrent.state == "queuedUP"
+        case .completed:
+            return torrent.state == "uploading"
                 || torrent.state == "stalledUP"
                 || torrent.state == "checkingUP"
                 || torrent.state == "forcedUP"
@@ -34,10 +40,7 @@ struct QBitTorrentFilterStrategy: TorrentFilterStrategy {
                 || torrent.state == "stoppedDL"
                 || torrent.state == "stoppedUP"
         case .active:
-            return !torrent.state.contains("paused")
-                && !torrent.state.contains("stopped")
-                && torrent.state != "error"
-                && torrent.state != "missingFiles"
+            return torrent.dlspeed > 0 || torrent.upspeed > 0
         case .inactive:
             return torrent.dlspeed == 0 && torrent.upspeed == 0
         case .stalled:
@@ -53,7 +56,10 @@ struct QBitTorrentFilterStrategy: TorrentFilterStrategy {
         case .errored:
             return torrent.state == "error" || torrent.state == "missingFiles"
         case .running:
-            return !torrent.state.contains("paused") && !torrent.state.contains("stopped")
+            return !torrent.state.contains("paused")
+                && !torrent.state.contains("stopped")
+                && torrent.state != "error"
+                && torrent.state != "missingFiles"
         case .moving:
             return torrent.state == "moving"
         case .all:

--- a/qBitControl/Models/TorrentFilterStrategy.swift
+++ b/qBitControl/Models/TorrentFilterStrategy.swift
@@ -28,7 +28,7 @@ struct QBitTorrentFilterStrategy: TorrentFilterStrategy {
                 || torrent.state == "queuedUP"
                 || torrent.state == "pausedUP"
                 || torrent.state == "stoppedUP"
-        case .paused:
+        case .stopped:
             return torrent.state == "pausedDL"
                 || torrent.state == "pausedUP"
                 || torrent.state == "stoppedDL"
@@ -52,8 +52,10 @@ struct QBitTorrentFilterStrategy: TorrentFilterStrategy {
                 || torrent.state == "checkingResumeData"
         case .errored:
             return torrent.state == "error" || torrent.state == "missingFiles"
-        case .resumed:
+        case .running:
             return !torrent.state.contains("paused") && !torrent.state.contains("stopped")
+        case .moving:
+            return torrent.state == "moving"
         case .all:
             return true
         }

--- a/qBitControl/Models/TorrentFilterStrategy.swift
+++ b/qBitControl/Models/TorrentFilterStrategy.swift
@@ -1,0 +1,61 @@
+//
+//  TorrentFilterStrategy.swift
+//  qBitControl
+//
+
+import Foundation
+
+protocol TorrentFilterStrategy {
+    func matches(_ torrent: Torrent, filter: TorrentFilterOption) -> Bool
+}
+
+struct QBitTorrentFilterStrategy: TorrentFilterStrategy {
+    func matches(_ torrent: Torrent, filter: TorrentFilterOption) -> Bool {
+        switch filter {
+        case .downloading:
+            return torrent.state == "downloading"
+                || torrent.state == "stalledDL"
+                || torrent.state == "checkingDL"
+                || torrent.state == "metaDL"
+                || torrent.state == "forcedDL"
+                || torrent.state == "allocating"
+        case .completed, .seeding:
+            return torrent.state == "seeding"
+                || torrent.state == "uploading"
+                || torrent.state == "stalledUP"
+                || torrent.state == "checkingUP"
+                || torrent.state == "forcedUP"
+                || torrent.state == "queuedUP"
+                || torrent.state == "pausedUP"
+                || torrent.state == "stoppedUP"
+        case .paused:
+            return torrent.state == "pausedDL"
+                || torrent.state == "pausedUP"
+                || torrent.state == "stoppedDL"
+                || torrent.state == "stoppedUP"
+        case .active:
+            return !torrent.state.contains("paused")
+                && !torrent.state.contains("stopped")
+                && torrent.state != "error"
+                && torrent.state != "missingFiles"
+        case .inactive:
+            return torrent.dlspeed == 0 && torrent.upspeed == 0
+        case .stalled:
+            return torrent.state == "stalledDL" || torrent.state == "stalledUP"
+        case .stalledDownloading:
+            return torrent.state == "stalledDL"
+        case .stalledUploading:
+            return torrent.state == "stalledUP"
+        case .checking:
+            return torrent.state == "checkingDL"
+                || torrent.state == "checkingUP"
+                || torrent.state == "checkingResumeData"
+        case .errored:
+            return torrent.state == "error" || torrent.state == "missingFiles"
+        case .resumed:
+            return !torrent.state.contains("paused") && !torrent.state.contains("stopped")
+        case .all:
+            return true
+        }
+    }
+}

--- a/qBitControl/ViewModels/TorrentView/TorrentDetailsViewModel.swift
+++ b/qBitControl/ViewModels/TorrentView/TorrentDetailsViewModel.swift
@@ -135,14 +135,15 @@ class TorrentDetailsViewModel: ObservableObject {
         haptics.impactOccurred()
         let isCurrentlyPaused = self.isPaused()
         
-        let newState = isCurrentlyPaused 
-            ? (self.torrent.progress < 1.0 ? "downloading" : "uploading") 
-            : (self.torrent.progress < 1.0 ? "pausedDL" : "pausedUP")
-        self.torrent.state = newState
-        self.fetchState(state: newState)
+        if isCurrentlyPaused {
+            self.torrent.applyResume()
+        } else {
+            self.torrent.applyPause()
+        }
+        self.fetchState(state: torrent.state)
         
         qBitData.shared.cacheManager.updateTorrentsOptimistically(hashes: [torrent.hash]) { torrent in
-            torrent.state = newState
+            isCurrentlyPaused ? torrent.applyResume() : torrent.applyPause()
         }
         
         Task {
@@ -189,14 +190,15 @@ class TorrentDetailsViewModel: ObservableObject {
     }
     
     func setForceStart(value: Bool) {
-        let newState = value 
-            ? (self.torrent.progress < 1.0 ? "forcedDL" : "forcedUP")
-            : (self.torrent.progress < 1.0 ? "downloading" : "uploading")
-        self.torrent.state = newState
-        self.fetchState(state: newState)
+        if value {
+            self.torrent.applyForceStart()
+        } else {
+            self.torrent.applyForceStartStop()
+        }
+        self.fetchState(state: torrent.state)
         
         qBitData.shared.cacheManager.updateTorrentsOptimistically(hashes: [torrent.hash]) { torrent in
-            torrent.state = newState
+            value ? torrent.applyForceStart() : torrent.applyForceStartStop()
         }
         
         Task {
@@ -210,12 +212,11 @@ class TorrentDetailsViewModel: ObservableObject {
     
     func recheckTorrent() {
         haptics.impactOccurred()
-        let newState = self.torrent.progress < 1.0 ? "checkingDL" : "checkingUP"
-        self.torrent.state = newState
-        self.fetchState(state: newState)
+        self.torrent.applyRecheck()
+        self.fetchState(state: torrent.state)
         
         qBitData.shared.cacheManager.updateTorrentsOptimistically(hashes: [torrent.hash]) { torrent in
-            torrent.state = newState
+            torrent.applyRecheck()
         }
         
         Task {

--- a/qBitControl/ViewModels/TorrentView/TorrentListHelperViewModel.swift
+++ b/qBitControl/ViewModels/TorrentView/TorrentListHelperViewModel.swift
@@ -10,6 +10,7 @@ import Combine
 class TorrentListHelperViewModel: ObservableObject {
     let defaults = UserDefaults.standard
     private let client: TorrentClientProtocol
+    private let filterStrategy: TorrentFilterStrategy
     
     @Published public var torrents: [Torrent] = []
     
@@ -47,8 +48,9 @@ class TorrentListHelperViewModel: ObservableObject {
         return category.capitalized
     }
     
-    init(client: TorrentClientProtocol) {
+    init(client: TorrentClientProtocol, filterStrategy: TorrentFilterStrategy = QBitTorrentFilterStrategy()) {
         self.client = client
+        self.filterStrategy = filterStrategy
         setupSubscriptions()
     }
     
@@ -101,32 +103,7 @@ class TorrentListHelperViewModel: ObservableObject {
     ) -> [Torrent] {
         var list = allTorrents.filter { torrent in
             // Filter by status (filterVal)
-            switch filterVal {
-            case .downloading:
-                if !(torrent.state == "downloading" || torrent.state == "stalledDL" || torrent.state == "checkingDL" || torrent.state == "metaDL" || torrent.state == "forcedDL" || torrent.state == "allocating") { return false }
-            case .completed, .seeding:
-                if !(torrent.state == "seeding" || torrent.state == "uploading" || torrent.state == "stalledUP" || torrent.state == "checkingUP" || torrent.state == "forcedUP" || torrent.state == "queuedUP" || torrent.state == "pausedUP" || torrent.state == "stoppedUP") { return false }
-            case .paused:
-                if !(torrent.state == "pausedDL" || torrent.state == "pausedUP" || torrent.state == "stoppedDL" || torrent.state == "stoppedUP") { return false }
-            case .active:
-                if !(torrent.dlspeed > 0 || torrent.upspeed > 0) { return false }
-            case .inactive:
-                if !(torrent.dlspeed == 0 && torrent.upspeed == 0) { return false }
-            case .stalled:
-                if !(torrent.state == "stalledDL" || torrent.state == "stalledUP") { return false }
-            case .stalledDownloading:
-                if !(torrent.state == "stalledDL") { return false }
-            case .stalledUploading:
-                if !(torrent.state == "stalledUP") { return false }
-            case .checking:
-                if !(torrent.state == "checkingDL" || torrent.state == "checkingUP" || torrent.state == "checkingResumeData") { return false }
-            case .errored:
-                if !(torrent.state == "error" || torrent.state == "missingFiles") { return false }
-            case .resumed:
-                if torrent.state.contains("paused") || torrent.state.contains("stopped") { return false }
-            case .all:
-                break
-            }
+            if !filterStrategy.matches(torrent, filter: filterVal) { return false }
             
             // Filter by Category
             if categoryVal != "All" {
@@ -327,7 +304,7 @@ class TorrentListHelperViewModel: ObservableObject {
     
     func resumeTorrents(hashes: [String]) {
         qBitData.shared.cacheManager.updateTorrentsOptimistically(hashes: hashes) { torrent in
-            torrent.state = torrent.progress < 1.0 ? "downloading" : "uploading"
+            torrent.applyResume()
         }
         Task {
             do {
@@ -341,7 +318,7 @@ class TorrentListHelperViewModel: ObservableObject {
     func resumeAllTorrents() {
         let hashes = torrents.map { $0.hash }
         qBitData.shared.cacheManager.updateTorrentsOptimistically(hashes: hashes) { torrent in
-            torrent.state = torrent.progress < 1.0 ? "downloading" : "uploading"
+            torrent.applyResume()
         }
         Task {
             do {
@@ -355,9 +332,7 @@ class TorrentListHelperViewModel: ObservableObject {
     func pauseAllTorrents() {
         let hashes = torrents.map { $0.hash }
         qBitData.shared.cacheManager.updateTorrentsOptimistically(hashes: hashes) { torrent in
-            torrent.state = torrent.progress < 1.0 ? "pausedDL" : "pausedUP"
-            torrent.dlspeed = 0
-            torrent.upspeed = 0
+            torrent.applyPause()
         }
         Task {
             do {
@@ -370,9 +345,7 @@ class TorrentListHelperViewModel: ObservableObject {
     
     func pauseTorrents(hashes: [String]) {
         qBitData.shared.cacheManager.updateTorrentsOptimistically(hashes: hashes) { torrent in
-            torrent.state = torrent.progress < 1.0 ? "pausedDL" : "pausedUP"
-            torrent.dlspeed = 0
-            torrent.upspeed = 0
+            torrent.applyPause()
         }
         Task {
             do {
@@ -405,7 +378,7 @@ class TorrentListHelperViewModel: ObservableObject {
     
     func recheckTorrents(hashes: [String]) {
         qBitData.shared.cacheManager.updateTorrentsOptimistically(hashes: hashes) { torrent in
-            torrent.state = torrent.progress < 1.0 ? "checkingDL" : "checkingUP"
+            torrent.applyRecheck()
         }
         Task {
             do {

--- a/qBitControl/Views/TorrentViews/FiltersMenuView.swift
+++ b/qBitControl/Views/TorrentViews/FiltersMenuView.swift
@@ -55,18 +55,20 @@ struct FiltersMenuView: View {
                 Picker("Filter By", selection: $filter) {
                     Group {
                         Text("All").tag(TorrentFilterOption.all)
-                        Text("Resumed").tag(TorrentFilterOption.resumed)
-                        Text("Seeding").tag(TorrentFilterOption.stalledUploading)
-                        Text("Downloading").tag(TorrentFilterOption.stalledDownloading)
-                        Text("Active Downloading").tag(TorrentFilterOption.downloading)
-                        Text("Active Seeding").tag(TorrentFilterOption.seeding)
+                        Text("Running").tag(TorrentFilterOption.running)
+                        Text("Seeding").tag(TorrentFilterOption.seeding)
+                        Text("Downloading").tag(TorrentFilterOption.downloading)
                         Text("Completed").tag(TorrentFilterOption.completed)
-                        Text("Paused").tag(TorrentFilterOption.paused)
+                        Text("Stopped").tag(TorrentFilterOption.stopped)
                         Text("Active").tag(TorrentFilterOption.active)
                         Text("Inactive").tag(TorrentFilterOption.inactive)
                     }
                     Group {
                         Text("Stalled").tag(TorrentFilterOption.stalled)
+                        Text("Stalled Uploading").tag(TorrentFilterOption.stalledUploading)
+                        Text("Stalled Downloading").tag(TorrentFilterOption.stalledDownloading)
+                        Text("Checking").tag(TorrentFilterOption.checking)
+                        Text("Moving").tag(TorrentFilterOption.moving)
                         Text("Errored").tag(TorrentFilterOption.errored)
                     }
                 }.pickerStyle(.inline)

--- a/qBitControl/Views/TorrentViews/FiltersMenuView.swift
+++ b/qBitControl/Views/TorrentViews/FiltersMenuView.swift
@@ -19,9 +19,37 @@ struct FiltersMenuView: View {
     @Binding var tag: String
     
     private let defaults = UserDefaults.standard
+    private let filterStrategy = QBitTorrentFilterStrategy()
+    @ObservedObject private var cacheManager = qBitData.shared.cacheManager
+    private var torrents: [Torrent] { Array(cacheManager.torrents.values) }
     
     private var client: TorrentClientProtocol {
         ServersHelper.shared.client ?? MockTorrentClient()
+    }
+    
+    private func count(for option: TorrentFilterOption) -> Int {
+        torrents.filter { filterStrategy.matches($0, filter: option) }.count
+    }
+    
+    private func filterRow(_ label: String, option: TorrentFilterOption) -> some View {
+        Button {
+            filter = option
+            defaults.set(filter.rawValue, forKey: "filter")
+        } label: {
+            HStack {
+                Text(label)
+                    .foregroundColor(.primary)
+                Spacer()
+                if filter == option {
+                    Image(systemName: "checkmark")
+                        .foregroundColor(.accentColor)
+                } else {
+                    Text("\(count(for: option))")
+                        .foregroundColor(.secondary)
+                        .font(.footnote)
+                }
+            }
+        }
     }
     
     var body: some View {
@@ -52,29 +80,22 @@ struct FiltersMenuView: View {
                     }
                 }.pickerStyle(.inline)
                 
-                Picker("Filter By", selection: $filter) {
-                    Group {
-                        Text("All").tag(TorrentFilterOption.all)
-                        Text("Running").tag(TorrentFilterOption.running)
-                        Text("Seeding").tag(TorrentFilterOption.seeding)
-                        Text("Downloading").tag(TorrentFilterOption.downloading)
-                        Text("Completed").tag(TorrentFilterOption.completed)
-                        Text("Stopped").tag(TorrentFilterOption.stopped)
-                        Text("Active").tag(TorrentFilterOption.active)
-                        Text("Inactive").tag(TorrentFilterOption.inactive)
-                    }
-                    Group {
-                        Text("Stalled").tag(TorrentFilterOption.stalled)
-                        Text("Stalled Uploading").tag(TorrentFilterOption.stalledUploading)
-                        Text("Stalled Downloading").tag(TorrentFilterOption.stalledDownloading)
-                        Text("Checking").tag(TorrentFilterOption.checking)
-                        Text("Moving").tag(TorrentFilterOption.moving)
-                        Text("Errored").tag(TorrentFilterOption.errored)
-                    }
-                }.pickerStyle(.inline)
-                    .onChange(of: filter, perform: { value in
-                    defaults.set(filter.rawValue, forKey: "filter")
-                })
+                Section(header: Text("Filter By")) {
+                    filterRow("All", option: .all)
+                    filterRow("Downloading", option: .downloading)
+                    filterRow("Seeding", option: .seeding)
+                    filterRow("Completed", option: .completed)
+                    filterRow("Running", option: .running)
+                    filterRow("Stopped", option: .stopped)
+                    filterRow("Active", option: .active)
+                    filterRow("Inactive", option: .inactive)
+                    filterRow("Stalled", option: .stalled)
+                    filterRow("Stalled Uploading", option: .stalledUploading)
+                    filterRow("Stalled Downloading", option: .stalledDownloading)
+                    filterRow("Checking", option: .checking)
+                    filterRow("Moving", option: .moving)
+                    filterRow("Errored", option: .errored)
+                }
                 
                 Picker("Sort By", selection: $sort) {
                     Group {

--- a/qBitControlTests/TorrentCacheManagerTests.swift
+++ b/qBitControlTests/TorrentCacheManagerTests.swift
@@ -42,7 +42,7 @@ final class TorrentCacheManagerTests: XCTestCase {
             "seen_complete": 1600000500,
             "seq_dl": false,
             "size": 5000000000,
-            "state": "seeding",
+            "state": "uploading",
             "super_seeding": false,
             "tags": "linux,distro",
             "time_active": 1000,

--- a/qBitControlTests/TorrentListHelperViewModelTests.swift
+++ b/qBitControlTests/TorrentListHelperViewModelTests.swift
@@ -126,7 +126,7 @@ final class TorrentListHelperViewModelTests: XCTestCase {
                 "seen_complete": 1600000500,
                 "seq_dl": false,
                 "size": 5000000000,
-                "state": "seeding",
+                "state": "uploading",
                 "super_seeding": false,
                 "tags": "linux,distro",
                 "time_active": 1000,
@@ -357,7 +357,7 @@ final class TorrentListHelperViewModelTests: XCTestCase {
         sut.filter = .seeding
         await sut.getTorrents()
         XCTAssertEqual(sut.filteredTorrents.count, 1)
-        XCTAssertEqual(sut.filteredTorrents.first?.state, "seeding")
+        XCTAssertEqual(sut.filteredTorrents.first?.state, "uploading")
         
         sut.filter = .downloading
         await sut.getTorrents()


### PR DESCRIPTION
Closes #127

## Summary
Fixes the pause-bug where pausing a torrent from the details view left it visible under the Active filter. Along the way, extracted a portable filter strategy, aligned filter names and ordering with qBittorrent 5.2.0 WebUI, and added per-filter counts.

## Key Changes
* **TorrentFilterStrategy**: New protocol + `QBitTorrentFilterStrategy` implementation. Extracted filter logic from `getProcessedTorrents` into a standalone, injectable strategy. Transmission-ready.
* **Single source of truth**: `Torrent` now has `applyPause()`, `applyResume()`, `applyForceStart()`, `applyRecheck()` methods — both ViewModels call the same transition logic, eliminating the drift that caused #127.
* **Filter alignment**: Removed fake filters (Resumed, Active Downloading, Active Seeding). Renamed Paused→Stopped, added Running/Moving. Order matches qBittorrent 5.2.0 WebUI.
* **Per-filter counts**: Each filter row shows a greyed-out count of matching torrents via a custom Button/checkmark layout. Counts reactively update from the cache manager.
* **Real state strings**: Removed fake states (`seeding`, `completed`) from strategy and test fixtures. Active filter reverted to speed-based (`dlspeed>0 || upspeed>0`) matching qBittorrent's actual behavior. Supports both `stoppedDL`/`pausedDL` variants for v4/v5 compatibility.

## Technical Notes
* UserDefaults saves filter via `rawValue` — old `resumed`/`paused` values gracefully fall back to `All`.
* `PickerStyle.inline` replaced with Section+Button for filter list to get checkmark/count alignment control.